### PR TITLE
feat(docker): dockerize app and MySQL database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 !**/src/test/**/out/
 .kotlin
 SmartCityGuide.iml
+.idea
 
 ### Eclipse ###
 .apt_generated
@@ -32,6 +33,10 @@ bin/
 
 ### AI Agents ###
 .agents/
+
+### Maven ###
+target/
+dependency-reduced-pom.xml
 
 ### Python ###
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Stage 1: Build the application
+FROM maven:3.9-eclipse-temurin-21-alpine AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn package -DskipTests -o
+
+# Stage 2: Run the application
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/app.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,43 @@ java com.smartcity.main.SmartCityApp
 
 ---
 
+### 🐳 Run with Docker
+
+No local Java or MySQL install needed — everything runs in containers.
+
+**Prerequisites:** Docker + Docker Compose.
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/Rajath2005/SmartCityApp.git
+cd SmartCityApp
+
+# 2. Build and start the app (attached to your terminal, since it's a CLI app)
+docker compose run --rm app
+```
+
+This spins up a MySQL container (auto-seeded with `db_setup.sql`) and runs the app against it. `docker compose run` keeps stdin/stdout attached so menu prompts work interactively.
+
+**Useful commands:**
+
+```bash
+# Start just the database in the background
+docker compose up -d mysql-db
+
+# Rebuild the app image after code changes
+docker compose build app
+
+# Reset the database (wipes all data, re-seeds on next run)
+docker compose down -v
+
+# Stop everything
+docker compose down
+```
+
+Default DB credentials (override via `DB_PASSWORD` env var before running compose): user `root`, password `root`, database `smart_city_guide`.
+
+---
+
 ## 🛠️ Technology Stack
 
 | Layer | Technology |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  mysql-db:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-root}
+      MYSQL_DATABASE: smart_city_guide
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./db_setup.sql:/docker-entrypoint-initdb.d/db_setup.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_PASSWORD:-root}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build: .
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+    environment:
+      DB_HOST: mysql-db
+      DB_PORT: 3306
+      DB_NAME: smart_city_guide
+      DB_USER: root
+      DB_PASSWORD: ${DB_PASSWORD:-root}
+    stdin_open: true
+    tty: true
+
+volumes:
+  mysql-data:

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.smartcity</groupId>
+    <artifactId>smart-city-guide</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mainClass>com.smartcity.main.SmartCityApp</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>9.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>app</finalName>
+        <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${mainClass}</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/com/smartcity/db/DBConnection.java
+++ b/src/com/smartcity/db/DBConnection.java
@@ -2,28 +2,34 @@ package com.smartcity.db;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Scanner;
 
 /**
  * Handles the database connection for the Smart City Guide application.
  * This class uses the Singleton pattern approach for providing a connection
- * to the MySQL database. It prompts the user for the root database password
- * upon initialization.
+ * to the MySQL database. Connection settings are read from environment
+ * variables so the app can run unattended (e.g. inside Docker).
  *
  * @author Rajath2005 (Original Creator)
  * @version 1.0
  */
 public class DBConnection {
-    // Database credentials
-    private static final String DB_URL = "jdbc:mysql://localhost:3306/smart_city_guide";
-    private static final String DB_USER = "root";
-    private static String DB_PASSWORD = "";
+    // Database credentials, overridable via environment variables
+    private static final String DB_HOST = getEnv("DB_HOST", "localhost");
+    private static final String DB_PORT = getEnv("DB_PORT", "3306");
+    private static final String DB_NAME = getEnv("DB_NAME", "smart_city_guide");
+    private static final String DB_URL = "jdbc:mysql://" + DB_HOST + ":" + DB_PORT + "/" + DB_NAME;
+    private static final String DB_USER = getEnv("DB_USER", "root");
+    private static final String DB_PASSWORD = getEnv("DB_PASSWORD", "");
+
+    private static String getEnv(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return (value == null || value.isEmpty()) ? defaultValue : value;
+    }
 
     /**
      * Static initialization block.
      * This block is executed once when the class is first loaded into memory.
-     * It loads the MySQL JDBC driver and securely prompts the developer
-     * for the database password via the console.
+     * It loads the MySQL JDBC driver.
      */
     static {
         // Load MySQL JDBC driver
@@ -35,12 +41,6 @@ public class DBConnection {
             System.out.println("   Please add mysql-connector-java JAR to your project.");
             e.printStackTrace();
         }
-
-
-        // Ask developer for database password
-        Scanner scanner = new Scanner(System.in);
-        System.out.print("\n🔐 Enter MySQL password for user 'root': ");
-        DB_PASSWORD = scanner.nextLine();
     }
 
     /**


### PR DESCRIPTION
Adds a Dockerfile (multi-stage Maven build + slim JRE runtime) and a docker-compose.yml that spins up MySQL alongside the app, auto-seeded with db_setup.sql. DBConnection now reads host/port/user/password from environment variables instead of hardcoding localhost and blocking on an interactive stdin password prompt, so the app can run unattended in a container. Closes #49.