### PR TITLE
feat(ci): add /assign and /take self-assign workflow

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,48 @@
+name: Self-Assign via Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  self-assign:
+    if: github.event.comment.body == '/assign' || github.event.comment.body == '/take'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign commenter to issue or PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const commenter = context.payload.comment.user.login;
+
+            const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number });
+
+            if (issue.assignees.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `@${commenter} this ${issue.pull_request ? 'PR' : 'issue'} is already assigned to ${issue.assignees.map(a => `@${a.login}`).join(', ')}.`,
+              });
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number,
+              assignees: [commenter],
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `👋 Assigned this ${issue.pull_request ? 'PR' : 'issue'} to @${commenter}.`,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,8 @@ Write clear, concise commit messages. Use the following format:
 
 New to open source? Look for issues tagged [`good first issue`](https://github.com/Rajath2005/SmartCityApp/issues?q=label%3A%22good+first+issue%22) — they are specifically selected to be beginner-friendly entry points into the codebase.
 
+> 💡 **Claiming an issue:** Found one you want to work on? Comment `/assign` or `/take` on it and our bot will assign it to you automatically (as long as it isn't already claimed).
+
 **Current Focus Areas for Beginners:**
 If you are looking for things to build, we highly recommend looking into these architectural improvements:
 1.  **Migrating to DAOs:** Currently, `SmartCityApp.java` handles all SQL queries. Refactoring this logic into separate Data Access Objects (e.g., `UserDAO.java`, `PlaceDAO.java`) is a great way to learn Layered Architecture!


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/self-assign.yml`) triggered on `issue_comment` that lets contributors self-assign an issue or PR by commenting `/assign` or `/take`
- Skips assignment if the issue/PR already has an assignee, and posts a comment either way so the action is visible
- Documents the command in `CONTRIBUTING.md` under Good First Issues

This lowers friction for new contributors claiming issues without needing a maintainer to manually assign them.

## Test plan
- [ ] Merge and comment `/assign` on a test issue to confirm the bot assigns the commenter
- [ ] Comment `/assign` again to confirm it responds with the existing assignee instead of reassigning
- [ ] Comment `/take` to confirm the alias works the same way