### PR TITLE
feat(ci): add Checkstyle linting on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Checkstyle Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  checkstyle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run Checkstyle
+        run: mvn -B checkstyle:check

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    SmartCityApp Checkstyle rules.
+
+    Kept intentionally lenient: only real defects (unused imports, missing
+    braces, equals/hashCode contract, empty blocks) are errors that fail the
+    build. Formatting nits (line length, whitespace) are warnings so existing
+    code isn't blocked while the project gradually adopts a consistent style.
+-->
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="warning"/>
+
+    <module name="FileTabCharacter">
+        <property name="severity" value="error"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="150"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="UnusedImports">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="RedundantImport">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="AvoidStarImport">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="EqualsHashCode">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="EmptyBlock">
+            <property name="severity" value="error"/>
+            <property name="option" value="text"/>
+        </module>
+
+        <module name="NeedBraces">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="EmptyCatchBlock">
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="WhitespaceAround"/>
+
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+        </module>
+
+        <module name="LocalVariableName"/>
+
+        <module name="ConstantName"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <violationSeverity>error</violationSeverity>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -6,8 +6,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import com.smartcity.model.User;
-import com.smartcity.model.Place;
 import com.smartcity.db.DBConnection;
 
 /**
@@ -71,8 +69,9 @@ public class SmartCityApp {
 
     // Validates username: 4-20 characters, alphanumeric only
     private static boolean isValidUsername(String username) {
-        if (username == null || username.isEmpty())
+        if (username == null || username.isEmpty()) {
             return false;
+        }
         String regex = "^[a-zA-Z0-9]{4,20}$";
         return username.matches(regex);
     }
@@ -80,8 +79,9 @@ public class SmartCityApp {
     // Validates password: Minimum 8 chars, 1 uppercase, 1 lowercase, 1 number, 1
     // special char
     private static boolean isValidPassword(String password) {
-        if (password == null || password.isEmpty())
+        if (password == null || password.isEmpty()) {
             return false;
+        }
         String regex = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
         return password.matches(regex);
     }
@@ -651,23 +651,19 @@ public class SmartCityApp {
             String newDescription = scanner.nextLine();
 
             // Use old values if input is empty
-            if (newName.isEmpty()) newName = currentName;
-            if (newCategory.isEmpty()) newCategory = currentCategory;
-            if (newLocation.isEmpty()) newLocation = currentLocation;
-            if (newDescription.isEmpty()) newDescription = currentDescription;
-
-            // Single correct update query
-            if (newName.isEmpty())
+            if (newName.isEmpty()) {
                 newName = currentName;
-            if (newCategory.isEmpty())
+            }
+            if (newCategory.isEmpty()) {
                 newCategory = currentCategory;
-            if (newLocation.isEmpty())
+            }
+            if (newLocation.isEmpty()) {
                 newLocation = currentLocation;
-            if (newDescription.isEmpty())
+            }
+            if (newDescription.isEmpty()) {
                 newDescription = currentDescription;
+            }
 
-         
-            // Single correct update query
             updatePstmt.setString(1, newName);
             updatePstmt.setString(2, newCategory);
             updatePstmt.setString(3, newLocation);


### PR DESCRIPTION
## Summary
- Adds a lenient `checkstyle.xml` ruleset wired into the Maven build via `maven-checkstyle-plugin`
- Adds `.github/workflows/lint.yml` running `mvn checkstyle:check` on every PR targeting `main`
- Real defects (unused imports, missing braces, empty catch blocks) fail the build; formatting nits (line length, whitespace, naming) are warnings only, so the existing codebase isn't immediately blocked while it adopts a consistent style
- Fixes the errors Checkstyle found in the current code: unused imports in `SmartCityApp.java`, single-line `if`s without braces, and a dead duplicate block in `updatePlace()` that repeated the same four null-coalescing checks twice

Closes #44

**Note:** this branch is based on #66 (adds `pom.xml`/Dockerfile), since Checkstyle needs a Maven build to run on. Please merge #66 first, or expect this PR's diff to include those changes until it's rebased.

## Test plan
- [x] `mvn verify` locally (in a maven:3.9-eclipse-temurin-21 container) — build succeeds, 0 errors, only style warnings remain
- [ ] CI: open a PR with an intentional unused import to confirm the workflow fails the check