### PR TITLE
Refactor: centralize DB connection null-check with helpful error message

### DIFF
--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -80,7 +80,7 @@ public class SmartCityApp {
 
     // Gets a database connection and prints a helpful error if it fails.
     // @return a valid Connection, or null if connection failed
-    private static Connection getConnectionOrExit() {
+    private static Connection getConnectionOrPrintError() {
         Connection conn = DBConnection.getConnection();
         if (conn == null) {
             System.out.println("❌ Could not connect to the database.");
@@ -138,7 +138,7 @@ public class SmartCityApp {
     // One-time startup migration: rehashes any legacy plaintext passwords to
     // SHA-256
     private static void migrateExistingPlaintextPasswords() {
-        Connection connection = getConnectionOrExit();
+        Connection connection = getConnectionOrPrintError();
 
         if (connection == null) {
             return;
@@ -203,7 +203,7 @@ public class SmartCityApp {
             password = scanner.nextLine();
         }
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -252,7 +252,7 @@ public class SmartCityApp {
         System.out.print("Enter password: ");
         String password = scanner.nextLine();
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -404,7 +404,7 @@ public class SmartCityApp {
 
     // Display all places in the city from MySQL database
     private static void viewAllPlaces() {
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -462,7 +462,7 @@ public class SmartCityApp {
         System.out.print("\nEnter category to search: ");
         String searchCategory = scanner.nextLine();
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -489,7 +489,7 @@ public class SmartCityApp {
         System.out.print("\nEnter location to search: ");
         String searchLocation = scanner.nextLine();
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -626,7 +626,7 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -670,7 +670,7 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }
@@ -818,7 +818,7 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = getConnectionOrExit()) {
+        try (Connection connection = getConnectionOrPrintError()) {
             if (connection == null) {
                 return;
             }

--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -78,6 +78,20 @@ public class SmartCityApp {
         scanner.close();
     }
 
+    // Gets a database connection and prints a helpful error if it fails.
+    // @return a valid Connection, or null if connection failed
+    private static Connection getConnectionOrExit() {
+        Connection conn = DBConnection.getConnection();
+        if (conn == null) {
+            System.out.println("❌ Could not connect to the database.");
+            System.out.println("   Please check:");
+            System.out.println("   1. Is MySQL running on your machine?");
+            System.out.println("   2. Did you run db_setup.sql to create the database?");
+            System.out.println("   3. Is your password correct?");
+        }
+        return conn;
+    }
+
     // Display menu options to user
     private static void displayMenu() {
         clearScreen();
@@ -121,19 +135,19 @@ public class SmartCityApp {
         }
     }
 
-    // One-time startup migration: rehashes any legacy plaintext passwords to SHA-256
+    // One-time startup migration: rehashes any legacy plaintext passwords to
+    // SHA-256
     private static void migrateExistingPlaintextPasswords() {
-        Connection connection = DBConnection.getConnection();
+        Connection connection = getConnectionOrExit();
 
         if (connection == null) {
-            System.out.println("❌ Skipped password migration: failed to connect to database.");
             return;
         }
 
         try (connection;
-             PreparedStatement selectPstmt = connection.prepareStatement(SELECT_ALL_CREDENTIALS_QUERY);
-             PreparedStatement updatePstmt = connection.prepareStatement(UPDATE_PASSWORD_QUERY);
-             ResultSet resultSet = selectPstmt.executeQuery()) {
+                PreparedStatement selectPstmt = connection.prepareStatement(SELECT_ALL_CREDENTIALS_QUERY);
+                PreparedStatement updatePstmt = connection.prepareStatement(UPDATE_PASSWORD_QUERY);
+                ResultSet resultSet = selectPstmt.executeQuery()) {
 
             int migratedCount = 0;
 
@@ -189,9 +203,8 @@ public class SmartCityApp {
             password = scanner.nextLine();
         }
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -239,9 +252,8 @@ public class SmartCityApp {
         System.out.print("Enter password: ");
         String password = scanner.nextLine();
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -392,14 +404,13 @@ public class SmartCityApp {
 
     // Display all places in the city from MySQL database
     private static void viewAllPlaces() {
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
             try (PreparedStatement pstmt = connection.prepareStatement(SELECT_ALL_PLACES_QUERY);
-                 ResultSet resultSet = pstmt.executeQuery()) {
+                    ResultSet resultSet = pstmt.executeQuery()) {
 
                 // Display header
                 System.out.println("\n🏙️  ===== ALL CITY ATTRACTIONS =====");
@@ -407,11 +418,11 @@ public class SmartCityApp {
                 PlaceResultPrintout(resultSet);
             }
 
-            } catch (SQLException e) {
-                System.out.println("❌ Error: Failed to fetch places from database.");
-                System.out.println("   Error message: " + e.getMessage());
-            }
+        } catch (SQLException e) {
+            System.out.println("❌ Error: Failed to fetch places from database.");
+            System.out.println("   Error message: " + e.getMessage());
         }
+    }
 
     // Display search menu with search options
     private static void searchPlacesMenu() {
@@ -451,9 +462,8 @@ public class SmartCityApp {
         System.out.print("\nEnter category to search: ");
         String searchCategory = scanner.nextLine();
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -479,9 +489,8 @@ public class SmartCityApp {
         System.out.print("\nEnter location to search: ");
         String searchLocation = scanner.nextLine();
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -617,10 +626,8 @@ public class SmartCityApp {
             return;
         }
 
-
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -663,9 +670,8 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 
@@ -717,7 +723,6 @@ public class SmartCityApp {
 
             System.out.print("Enter new longitude (or press Enter to keep current): ");
             String newLongitudeString = scanner.nextLine();
-
 
             // Use old values if input is empty
             if (newName.isEmpty()) {
@@ -813,9 +818,8 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = DBConnection.getConnection()) {
+        try (Connection connection = getConnectionOrExit()) {
             if (connection == null) {
-                System.out.println("❌ Failed to connect to database.");
                 return;
             }
 


### PR DESCRIPTION
Fixes #79

## What changed
Added a new helper method `getConnectionOrExit()` in `SmartCityApp.java` that centralizes the database connection + null-check logic, and gives the user a clear, actionable error message if the connection fails:

- Is MySQL running on your machine?
- Did you run db_setup.sql to create the database?
- Is your password correct?

Replaced all ~8 duplicated instances of the old pattern:
```java
Connection connection = DBConnection.getConnection();
if (connection == null) {
    System.out.println("❌ Failed to connect to database.");
    return;
}
```
with a single call to `getConnectionOrExit()`.

## Testing done
- Verified the project compiles successfully with `mvn compile`.
- Verified the failure path: with the DB unreachable, the app prints the new 3-point checklist message and returns cleanly to the menu without crashing.
- Verified the happy path with a real local MySQL instance: registered a new user, logged in successfully, and confirmed `viewAllPlaces()` and `searchPlaces()` (both touched by this refactor) run without errors.

## Notes
This is a structural change only — no new business logic was introduced, just centralizing existing duplicated code.