### PR TITLE
feat: include latitude and longitude in Place.toString()

### DIFF
--- a/src/com/smartcity/model/Place.java
+++ b/src/com/smartcity/model/Place.java
@@ -162,6 +162,8 @@ public class Place {
                 ", category='" + category + '\'' +
                 ", location='" + location + '\'' +
                 ", description='" + description + '\'' +
+                ", latitude=" + latitude +
+                ", longitude=" + longitude +
                 '}';
     }
 


### PR DESCRIPTION
## Summary

Closes #10

- `Place.toString()` was missing the `latitude` and `longitude` fields that were added after the initial `toString()` implementation — all 7 fields are now included
- `User.toString()` already correctly masks the password with `[PROTECTED]` — no change needed

## Test plan

- [x] Print a `Place` object and confirm output includes `latitude` and `longitude`
- [x] Print a `User` object and confirm password shows as `[PROTECTED]`
- [x] Verify no existing functionality is broken