### PR TITLE
fix: align Maven compiler target with JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>com.smartcity.main.SmartCityApp</mainClass>
     </properties>


### PR DESCRIPTION
## Description

This PR fixes a Java version mismatch that prevented the project from building with Docker.

### Problem
- `pom.xml` targeted Java 25.
- The Dockerfile uses Eclipse Temurin JDK 21.
- Running `docker compose run --rm app` failed with:

```text
error: invalid target release: 25
```

### Changes
- Updated the Maven compiler `source` and `target` versions from **25** to **21** to match the JDK used by the Docker build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Built and ran the project using:
  ```bash
  docker compose run --rm app
  ```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
