### PR TITLE
test: add JUnit 5 tests for Place and User model classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>com.smartcity.main.SmartCityApp</mainClass>
+        <junit.version>5.11.4</junit.version>
+        <surefire.version>3.5.2</surefire.version>
     </properties>
 
     <dependencies>
@@ -28,11 +30,19 @@
             <artifactId>jakarta.mail</artifactId>
             <version>2.0.1</version>
         </dependency>
+        <!-- Test-only: not bundled into the shaded application jar. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>app</finalName>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>tests</testSourceDirectory>
         <resources>
             <resource>
                 <directory>templates</directory>
@@ -40,6 +50,11 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/tests/com/smartcity/model/PlaceTest.java
+++ b/tests/com/smartcity/model/PlaceTest.java
@@ -1,0 +1,165 @@
+package com.smartcity.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link Place} model class.
+ *
+ * <p>Covers both constructors, every getter and setter, and the contract that
+ * {@code toString()} renders all fields without leaking literal {@code "null"}.
+ */
+class PlaceTest {
+
+    /** Tolerance for comparing latitude/longitude values. */
+    private static final double DELTA = 1e-9;
+
+    private Place place;
+
+    @BeforeEach
+    void setUp() {
+        place = new Place(1, "Central Park", "Park", "Downtown", "A beautiful green space");
+    }
+
+    @Nested
+    @DisplayName("Constructors")
+    class Constructors {
+
+        @Test
+        @DisplayName("legacy constructor populates every descriptive field")
+        void legacyConstructor_shouldPopulateDescriptiveFields() {
+            assertEquals(1, place.getId());
+            assertEquals("Central Park", place.getName());
+            assertEquals("Park", place.getCategory());
+            assertEquals("Downtown", place.getLocation());
+            assertEquals("A beautiful green space", place.getDescription());
+        }
+
+        @Test
+        @DisplayName("legacy constructor defaults coordinates to the -1 sentinel")
+        void legacyConstructor_shouldDefaultCoordinatesToMinusOne() {
+            assertEquals(-1.0, place.getLatitude(), DELTA);
+            assertEquals(-1.0, place.getLongitude(), DELTA);
+        }
+
+        @Test
+        @DisplayName("full constructor stores the supplied coordinates")
+        void fullConstructor_shouldStoreCoordinates() {
+            Place located = new Place(2, "City Museum", "Museum", "Old Town",
+                    "Local history exhibits", 12.9716, 77.5946);
+
+            assertEquals(2, located.getId());
+            assertEquals("City Museum", located.getName());
+            assertEquals(12.9716, located.getLatitude(), DELTA);
+            assertEquals(77.5946, located.getLongitude(), DELTA);
+        }
+    }
+
+    @Nested
+    @DisplayName("Getters and setters")
+    class Accessors {
+
+        @Test
+        void getId_shouldReturn1() {
+            assertEquals(1, place.getId());
+        }
+
+        @Test
+        void getName_shouldReturnCentralPark() {
+            assertEquals("Central Park", place.getName());
+        }
+
+        @Test
+        void setId_shouldUpdateId() {
+            place.setId(42);
+            assertEquals(42, place.getId());
+        }
+
+        @Test
+        void setName_shouldUpdateName() {
+            place.setName("City Garden");
+            assertEquals("City Garden", place.getName());
+        }
+
+        @Test
+        void setCategory_shouldUpdateCategory() {
+            place.setCategory("Garden");
+            assertEquals("Garden", place.getCategory());
+        }
+
+        @Test
+        void setLocation_shouldUpdateLocation() {
+            place.setLocation("Uptown");
+            assertEquals("Uptown", place.getLocation());
+        }
+
+        @Test
+        void setDescription_shouldUpdateDescription() {
+            place.setDescription("Renovated in 2024");
+            assertEquals("Renovated in 2024", place.getDescription());
+        }
+
+        @Test
+        void setLatitude_shouldUpdateLatitude() {
+            place.setLatitude(51.5074);
+            assertEquals(51.5074, place.getLatitude(), DELTA);
+        }
+
+        @Test
+        void setLongitude_shouldUpdateLongitude() {
+            place.setLongitude(-0.1278);
+            assertEquals(-0.1278, place.getLongitude(), DELTA);
+        }
+    }
+
+    @Nested
+    @DisplayName("toString()")
+    class ToString {
+
+        @Test
+        void toString_shouldContainName() {
+            assertTrue(place.toString().contains("Central Park"));
+        }
+
+        @Test
+        void toString_shouldContainEveryDescriptiveField() {
+            String rendered = place.toString();
+
+            assertTrue(rendered.contains("id=1"), "id missing from: " + rendered);
+            assertTrue(rendered.contains("Park"), "category missing from: " + rendered);
+            assertTrue(rendered.contains("Downtown"), "location missing from: " + rendered);
+            assertTrue(rendered.contains("A beautiful green space"),
+                    "description missing from: " + rendered);
+        }
+
+        @Test
+        void toString_shouldContainCoordinates() {
+            place.setLatitude(12.9716);
+            place.setLongitude(77.5946);
+            String rendered = place.toString();
+
+            assertTrue(rendered.contains("latitude=12.9716"), "latitude missing from: " + rendered);
+            assertTrue(rendered.contains("longitude=77.5946"), "longitude missing from: " + rendered);
+        }
+
+        @Test
+        void toString_shouldNotContainNull() {
+            assertFalse(place.toString().contains("null"));
+        }
+
+        @Test
+        void toString_shouldReflectUpdatedName() {
+            place.setName("City Garden");
+            String rendered = place.toString();
+
+            assertTrue(rendered.contains("City Garden"));
+            assertFalse(rendered.contains("Central Park"));
+        }
+    }
+}

--- a/tests/com/smartcity/model/UserTest.java
+++ b/tests/com/smartcity/model/UserTest.java
@@ -1,0 +1,121 @@
+package com.smartcity.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link User} model class.
+ *
+ * <p>The most important guarantee exercised here is that the password never
+ * escapes through {@code toString()}, since user objects are routinely printed
+ * to logs and to the console.
+ */
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User("alice", "secret");
+    }
+
+    @Nested
+    @DisplayName("Constructor and accessors")
+    class Accessors {
+
+        @Test
+        void constructor_shouldStoreUsername() {
+            assertEquals("alice", user.getUsername());
+        }
+
+        @Test
+        void constructor_shouldStorePassword() {
+            assertEquals("secret", user.getPassword());
+        }
+
+        @Test
+        void defaultRole_shouldBeUser() {
+            assertEquals("USER", user.getRole());
+        }
+
+        @Test
+        void setUsername_shouldUpdateUsername() {
+            user.setUsername("bob");
+            assertEquals("bob", user.getUsername());
+        }
+
+        @Test
+        void setRole_shouldPromoteToAdmin() {
+            user.setRole("ADMIN");
+            assertEquals("ADMIN", user.getRole());
+        }
+
+        @Test
+        @DisplayName("each new user starts with the USER role independently")
+        void newUsers_shouldNotShareRoleState() {
+            user.setRole("ADMIN");
+            User other = new User("carol", "pass");
+
+            assertEquals("USER", other.getRole());
+            assertEquals("ADMIN", user.getRole());
+        }
+    }
+
+    @Nested
+    @DisplayName("Password protection")
+    class PasswordProtection {
+
+        @Test
+        void toString_shouldNotExposePassword() {
+            assertFalse(user.toString().contains("secret"));
+        }
+
+        @Test
+        void toString_shouldMaskPasswordWithPlaceholder() {
+            assertTrue(user.toString().contains("[PROTECTED]"),
+                    "expected a masked password in: " + user.toString());
+        }
+
+        @Test
+        @DisplayName("password stays masked no matter what value it holds")
+        void toString_shouldNotExposeUnusualPasswords() {
+            User odd = new User("dave", "p@ssw0rd!#$");
+            assertFalse(odd.toString().contains("p@ssw0rd!#$"));
+        }
+
+        @Test
+        @DisplayName("no public setPassword() is exposed on the model")
+        void user_shouldNotExposePublicPasswordSetter() {
+            assertThrows(NoSuchMethodException.class,
+                    () -> User.class.getMethod("setPassword", String.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("toString()")
+    class ToString {
+
+        @Test
+        void toString_shouldContainUsername() {
+            assertTrue(user.toString().contains("alice"));
+        }
+
+        @Test
+        void toString_shouldContainRole() {
+            user.setRole("ADMIN");
+            assertTrue(user.toString().contains("ADMIN"));
+        }
+
+        @Test
+        void toString_shouldNotContainNull() {
+            assertFalse(user.toString().contains("null"));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #87

Adds JUnit 5 coverage for the two model classes and wires the test infrastructure into the build.

- `tests/com/smartcity/model/PlaceTest.java` — 17 tests covering both constructors, all seven getters/setters, and `toString()`
- `tests/com/smartcity/model/UserTest.java` — 13 tests covering the constructor, accessors, the default `USER` role, and password protection
- `pom.xml` — adds `junit-jupiter` at `test` scope, pins `maven-surefire-plugin`, and sets `<testSourceDirectory>tests</testSourceDirectory>`

No existing source file is modified. The JUnit dependency is test-scoped, so `target/app.jar` is byte-for-byte unaffected.

Tests use the package `com.smartcity.model` so they sit in a proper package rather than the default one; that requires the `com/smartcity/model/` path under `tests/`.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] `mvn test` — 30 tests, 0 failures, 0 errors
- [x] `mvn checkstyle:check` — 0 violations, no new warnings
- [x] `mvn package` — succeeds; verified no JUnit classes land in the shaded jar
- [x] Verified the tests fail when the behaviour they assert is deliberately broken (password leak, changed default role, changed coordinate default)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
