### PR TITLE
feature added menu-invalid-choice-guidance

### DIFF
--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -80,7 +80,7 @@ public class SmartCityApp {
                     isRunning = false;
                     break;
                 default:
-                    System.out.println("Invalid choice. Please try again.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 3.");
             }
         }
 
@@ -392,7 +392,7 @@ public class SmartCityApp {
                     inAdminMenu = false;
                     break;
                 default:
-                    System.out.println("Invalid choice. Please try again.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 4.");
             }
         }
     }
@@ -446,7 +446,7 @@ public class SmartCityApp {
                     inUserMenu = false;
                     break;
                 default:
-                    System.out.println("Invalid choice. Please try again.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 6.");
             }
         }
     }
@@ -576,7 +576,7 @@ public class SmartCityApp {
                     inSearchMenu = false;
                     break;
                 default:
-                    System.out.println("Invalid choice. Please try again.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 3.");
             }
         }
     }
@@ -680,7 +680,7 @@ public class SmartCityApp {
                     inResourceMenu = false;
                     break;
                 default:
-                    System.out.println("Invalid choice. Please try again.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 4.");
             }
         }
     }


### PR DESCRIPTION
## Description

Every menu's `switch` fell through to the same generic line:

```
Invalid choice. Please try again.
```

That tells the user they were wrong, but not what "right" looks like. This PR updates all five `default` cases to echo back the value that was entered and state the valid range for that specific menu.

```java
// Before
default:
    System.out.println("Invalid choice. Please try again.");

// After
default:
    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 3.");
```

All five live in `src/com/smartcity/main/SmartCityApp.java`:

| Menu | Line | Range |
|---|---|---|
| Main | 83 | 1–3 |
| Admin | 395 | 1–4 |
| User | 449 | 1–6 |
| Search | 579 | 1–3 |
| Manage Resources | 683 | 1–4 |

No control flow was touched — only the string literals inside `default:`. No new dependencies.

**One deviation from the issue, on purpose:** the issue lists the user menu as 1–5, but `showUserMenu()` actually has six cases (Logout is `case 6`), so its message says **1–6**. Printing "between 1 and 5" would have been a wrong message shipped as the fix for a wrong message.

Fixes #77

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] **Compiles clean** — `mvn -B compile` exits 0 with no errors and no new warnings.
- [ ] **Not run end-to-end.** The app calls `migrateExistingPlaintextPasswords()` on startup and every menu path opens a DB connection, so a live MySQL instance seeded with `db_setup.sql` is needed to exercise the menus. I did not have one, so the new strings were verified by reading them, not by watching them print.

To reproduce manually once a DB is available:

1. `mvn -B compile`
2. Run `com.smartcity.main.SmartCityApp`
3. At the main menu enter `9` → expect `❌ Invalid choice '9'. Please enter a number between 1 and 3.`
4. Log in, and repeat with an out-of-range number in the User, Search, Admin, and Manage Resources menus.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — *n/a, the diff is five message strings; no new logic to explain*
- [ ] I have made corresponding changes to the documentation — *no docs reference these strings*
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — *there is no Java test harness in this repo: `pom.xml` declares no JUnit or surefire, and `tests/` holds only Python tests unrelated to the CLI*
- [ ] New and existing unit tests pass locally with my changes — *same reason; no Java suite exists to run*
- [ ] Any dependent changes have been merged and published in downstream modules — *n/a*

## Out of scope (flagging, not fixing here)

Two pre-existing problems surfaced while making this change. Both need logic changes, which #77 explicitly excludes, so I left them alone — happy to open separate issues:

1. **The user menu's printed labels are off by one from its `switch`.** The menu prints five options ending in `5. 🚪 Logout`, but `case 5` prints "Opening navigation..." and `case 6` is the actual logout. So a user following the on-screen numbering cannot log out.
2. **Non-numeric input still crashes the app.** Every menu reads via `scanner.nextInt()` with no guard, so typing `abc` throws an uncaught `InputMismatchException` before the `switch` runs. The issue's example of `abc` therefore never reaches these `default` cases — this PR improves `9`, but not `abc`.
