### PR TITLE
Feat/deactivate user 88

### DIFF
--- a/db_setup.sql
+++ b/db_setup.sql
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) NOT NULL UNIQUE,
     role VARCHAR(20) DEFAULT 'USER'
 );
+-- Add soft-delete support. A deactivated account keeps its row (and its
+-- history) but is refused at login until an administrator restores it.
+ALTER TABLE users
+    ADD COLUMN is_active BOOLEAN DEFAULT TRUE;
 
 -- Table for Places
 CREATE TABLE IF NOT EXISTS places (

--- a/migrations/V3__add_is_active_column.sql
+++ b/migrations/V3__add_is_active_column.sql
@@ -1,0 +1,5 @@
+-- Adds soft-delete support to databases created before is_active existed.
+-- Existing rows take the column default, so every current account stays active
+-- and nobody is locked out by running this migration.
+ALTER TABLE users
+    ADD COLUMN is_active BOOLEAN DEFAULT TRUE;

--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -6,10 +6,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.InputMismatchException;
+import java.util.List;
+import java.util.Random;
 import java.util.Scanner;
 
 import com.smartcity.db.DBConnection;
+import com.smartcity.model.Place;
 import com.smartcity.service.EmailService;
 
 /**
@@ -40,6 +45,8 @@ public class SmartCityApp {
     private static final String DELETE_PLACE_QUERY = "DELETE FROM places WHERE id = ?";
     private static final String SELECT_ALL_CREDENTIALS_QUERY = "SELECT id, password FROM users";
     private static final String COUNT_PLACES_QUERY = "SELECT COUNT(*) FROM places";
+    // Ordering by id makes the offset stable, so the same day always lands on the same place
+    private static final String SELECT_PLACE_AT_OFFSET_QUERY = "SELECT * FROM places ORDER BY id LIMIT 1 OFFSET ?";
     private static final String COUNT_USERS_QUERY = "SELECT COUNT(*) FROM users";
     private static final String COUNT_PLACES_BY_CATEGORY_QUERY =
             "SELECT category, COUNT(*) AS cnt FROM places GROUP BY category ORDER BY cnt DESC, category ASC";
@@ -53,6 +60,10 @@ public class SmartCityApp {
     // Layout of the City Stats box, measured in terminal columns
     private static final int STATS_BOX_WIDTH = 44;
     private static final int STATS_LABEL_COLUMN = 27;
+
+    // Layout of the Place of the Day card, measured in terminal columns
+    private static final int PLACE_CARD_WIDTH = 46;
+    private static final int PLACE_CARD_COLON_COLUMN = 16;
 
     /**
      * Application entry point. Starts the Smart City Guide CLI, runs a
@@ -658,6 +669,8 @@ public class SmartCityApp {
                         if (role.equals("ADMIN")) {
                             showAdminMenu(username);
                         } else {
+                            // Regulars get a daily attraction spotlight; admins do not
+                            showPlaceOfTheDay(connection);
                             showUserMenu(username);
                         }
                     } else {
@@ -670,6 +683,219 @@ public class SmartCityApp {
             System.out.println("❌ Error: Failed to login user.");
             System.out.println("   Error message: " + e.getMessage());
         }
+    }
+
+    /**
+     * Prints the "Place of the Day" card: a single attraction spotlighted for
+     * the whole calendar day, shown to regular users right after they log in.
+     * <p>
+     * The pick is deterministic rather than random: the current date (as an
+     * epoch day number) seeds the generator, so every login on the same day
+     * lands on the same place, and the spotlight rolls over at midnight.
+     * If the city has no attractions recorded yet, a friendly nudge is printed
+     * instead of the card.
+     *
+     * @param connection an open database connection, reused from the login check
+     */
+    private static void showPlaceOfTheDay(Connection connection) {
+        try {
+            int totalPlaces = countRows(connection, COUNT_PLACES_QUERY);
+
+            if (totalPlaces == 0) {
+                printEmptyPlaceOfTheDayCard();
+            } else {
+                Place place = findPlaceOfTheDay(connection, totalPlaces);
+
+                if (place == null) {
+                    // The row count and the row fetch are separate queries, so a
+                    // place deleted between them would leave us empty-handed.
+                    printEmptyPlaceOfTheDayCard();
+                } else {
+                    printPlaceOfTheDayCard(place);
+                }
+            }
+        } catch (SQLException e) {
+            // A missing spotlight should never block an otherwise successful login.
+            System.out.println("❌ Could not load the Place of the Day right now.");
+            System.out.println("   Error message: " + e.getMessage());
+        }
+
+        // The user menu clears the screen the moment it is drawn, so hold the
+        // card on screen until the user has actually had a chance to read it.
+        System.out.print("\nPress Enter to continue to your menu... ");
+        scanner.nextLine();
+    }
+
+    /**
+     * Picks today's featured place. The date seeds the generator so the choice
+     * is stable for the whole day, and that choice becomes an offset into the
+     * id-ordered list of places.
+     *
+     * @param connection  an open database connection
+     * @param totalPlaces how many places exist, used to bound the offset
+     * @return the place featured today, or {@code null} if the row could not be read
+     * @throws SQLException if the lookup query fails
+     */
+    private static Place findPlaceOfTheDay(Connection connection, int totalPlaces) throws SQLException {
+        long seed = LocalDate.now().toEpochDay();
+        Random rng = new Random(seed);
+        int offset = rng.nextInt(totalPlaces);
+
+        try (PreparedStatement pstmt = connection.prepareStatement(SELECT_PLACE_AT_OFFSET_QUERY)) {
+            pstmt.setInt(1, offset);
+
+            try (ResultSet resultSet = pstmt.executeQuery()) {
+                if (!resultSet.next()) {
+                    return null;
+                }
+
+                return new Place(
+                        resultSet.getInt("id"),
+                        resultSet.getString("name"),
+                        resultSet.getString("category"),
+                        resultSet.getString("location"),
+                        resultSet.getString("description"),
+                        resultSet.getDouble("latitude"),
+                        resultSet.getDouble("longitude"));
+            }
+        }
+    }
+
+    /**
+     * Renders the featured place inside a bordered card.
+     *
+     * @param place the place to spotlight
+     */
+    private static void printPlaceOfTheDayCard(Place place) {
+        System.out.println();
+        System.out.println("╔" + "═".repeat(PLACE_CARD_WIDTH) + "╗");
+        System.out.println(centeredCardRow("✨  PLACE OF THE DAY  ✨"));
+        System.out.println("╠" + "═".repeat(PLACE_CARD_WIDTH) + "╣");
+        System.out.println(cardRow("  📍  " + truncateToWidth(place.getName(), PLACE_CARD_WIDTH - 8)));
+        System.out.println(cardField("🏷️", "Category", place.getCategory()));
+        System.out.println(cardField("📌", "Location", place.getLocation()));
+
+        printCardDescription(place.getDescription());
+
+        System.out.println(cardRow(""));
+        System.out.println(cardRow("  💡 Type '1' in the menu to explore more!"));
+        System.out.println("╚" + "═".repeat(PLACE_CARD_WIDTH) + "╝");
+    }
+
+    /**
+     * Prints the description as a quoted, word-wrapped block inside the card.
+     * Places with no description simply get no block, keeping the card tidy.
+     *
+     * @param description the place description, which may be null or blank
+     */
+    private static void printCardDescription(String description) {
+        if (description == null || description.trim().isEmpty()) {
+            return;
+        }
+
+        System.out.println(cardRow(""));
+
+        for (String line : wrapToWidth("\"" + description.trim() + "\"", PLACE_CARD_WIDTH - 6)) {
+            System.out.println(cardRow("   " + line));
+        }
+    }
+
+    /**
+     * Builds an "icon label : value" row of the card, keeping the colons of
+     * every field aligned to the same column.
+     *
+     * @param icon  the emoji shown at the start of the row
+     * @param label the field name
+     * @param value the field value, which may be null or blank
+     * @return the fully padded row, including its box borders
+     */
+    private static String cardField(String icon, String label, String value) {
+        String left = "  " + icon + "  " + label;
+        int gap = Math.max(1, PLACE_CARD_COLON_COLUMN - displayWidth(left));
+        String shown = (value == null || value.trim().isEmpty()) ? "—" : value.trim();
+        String right = ": " + truncateToWidth(shown, PLACE_CARD_WIDTH - PLACE_CARD_COLON_COLUMN - 4);
+
+        return cardRow(left + " ".repeat(gap) + right);
+    }
+
+    /**
+     * Wraps content in the vertical borders of the card, padding it on the
+     * right so the card keeps a straight edge.
+     *
+     * @param content the row content, without borders
+     * @return the bordered, right-padded row
+     */
+    private static String cardRow(String content) {
+        int padding = Math.max(0, PLACE_CARD_WIDTH - displayWidth(content));
+        return "║" + content + " ".repeat(padding) + "║";
+    }
+
+    /**
+     * Wraps content in the vertical borders of the card, centring it between them.
+     *
+     * @param content the row content, without borders
+     * @return the bordered, centred row
+     */
+    private static String centeredCardRow(String content) {
+        int padding = Math.max(0, PLACE_CARD_WIDTH - displayWidth(content));
+        int leftPadding = padding / 2;
+        return "║" + " ".repeat(leftPadding) + content + " ".repeat(padding - leftPadding) + "║";
+    }
+
+    /**
+     * Splits text into lines that each occupy at most {@code maxWidth} terminal
+     * columns, breaking on spaces wherever possible. A single word longer than
+     * the limit is cut short rather than allowed to overflow the card.
+     *
+     * @param text     the text to wrap
+     * @param maxWidth the maximum number of columns any one line may occupy
+     * @return the wrapped lines, in order
+     */
+    private static List<String> wrapToWidth(String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (String word : text.trim().split("\\s+")) {
+            if (current.length() == 0) {
+                current.append(word);
+            } else if (displayWidth(current.toString()) + 1 + displayWidth(word) <= maxWidth) {
+                current.append(' ').append(word);
+            } else {
+                lines.add(current.toString());
+                current.setLength(0);
+                current.append(word);
+            }
+
+            // A word too long to fit on a line of its own would still overflow.
+            if (displayWidth(current.toString()) > maxWidth) {
+                lines.add(truncateToWidth(current.toString(), maxWidth));
+                current.setLength(0);
+            }
+        }
+
+        if (current.length() > 0) {
+            lines.add(current.toString());
+        }
+
+        return lines;
+    }
+
+    /**
+     * Prints the fallback card shown when the city has no attractions recorded
+     * yet, so an empty database greets the user instead of showing nothing.
+     */
+    private static void printEmptyPlaceOfTheDayCard() {
+        System.out.println();
+        System.out.println("╔" + "═".repeat(PLACE_CARD_WIDTH) + "╗");
+        System.out.println(centeredCardRow("✨  PLACE OF THE DAY  ✨"));
+        System.out.println("╠" + "═".repeat(PLACE_CARD_WIDTH) + "╣");
+        System.out.println(cardRow(""));
+        System.out.println(centeredCardRow("🌱  No attractions to spotlight yet!"));
+        System.out.println(cardRow(""));
+        System.out.println(centeredCardRow("Check back soon — the city is"));
+        System.out.println(centeredCardRow("still being mapped out."));
+        System.out.println(cardRow(""));
+        System.out.println("╚" + "═".repeat(PLACE_CARD_WIDTH) + "╝");
     }
 
     /**

--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -46,7 +46,12 @@ public class SmartCityApp {
     // SQL Query Constants
     private static final String CHECK_USERNAME_EXISTS_QUERY = "SELECT id FROM users WHERE username = ?";
     private static final String INSERT_USER_QUERY = "INSERT INTO users (username, password, email, role) VALUES (?, ?, ?, ?)";
-    private static final String LOGIN_QUERY = "SELECT role FROM users WHERE username = ? AND password = ?";
+    private static final String LOGIN_QUERY = "SELECT role FROM users WHERE username = ? AND password = ? AND is_active = TRUE";
+    // Only consulted after a failed login, to tell a deactivated account apart from a wrong password
+    private static final String DEACTIVATED_ACCOUNT_QUERY = "SELECT id FROM users WHERE username = ? AND password = ? AND is_active = FALSE";
+    private static final String SELECT_ACTIVE_NON_ADMIN_USERS_QUERY =
+            "SELECT username FROM users WHERE role != 'ADMIN' AND is_active = TRUE ORDER BY username ASC";
+    private static final String DEACTIVATE_USER_QUERY = "UPDATE users SET is_active = FALSE WHERE username = ? AND role != 'ADMIN'";
     private static final String SEARCH_BY_CATEGORY_QUERY = "SELECT * FROM places WHERE LOWER(category) LIKE LOWER(?)";
     private static final String SEARCH_BY_LOCATION_QUERY = "SELECT * FROM places WHERE LOWER(location) LIKE LOWER(?)";
     private static final String INSERT_PLACE_QUERY = "INSERT INTO places (id, name, category, location, description, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?)";
@@ -653,6 +658,10 @@ public class SmartCityApp {
                             showPlaceOfTheDay(connection);
                             showUserMenu(username);
                         }
+                    } else if (isDeactivatedAccount(connection, username, hashPassword(password))) {
+                        // The credentials were right, so say why they were refused
+                        // rather than sending the user off to reset a working password.
+                        System.out.println("❌ This account has been deactivated. Please contact an administrator.");
                     } else {
                         System.out.println("❌ Error: Username or password incorrect. Please try again.");
                     }
@@ -662,6 +671,29 @@ public class SmartCityApp {
         } catch (SQLException e) {
             System.out.println("❌ Error: Failed to login user.");
             System.out.println("   Error message: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Checks whether a failed login was refused because the account is
+     * deactivated rather than because the credentials were wrong. Runs only
+     * after the login query has already come back empty.
+     *
+     * @param connection     an open database connection
+     * @param username       the username that was entered
+     * @param hashedPassword the hash of the password that was entered
+     * @return true if these credentials match an account that has been
+     *         deactivated
+     * @throws SQLException if the lookup fails
+     */
+    private static boolean isDeactivatedAccount(Connection connection, String username, String hashedPassword)
+            throws SQLException {
+        try (PreparedStatement pstmt = connection.prepareStatement(DEACTIVATED_ACCOUNT_QUERY)) {
+            pstmt.setString(1, username);
+            pstmt.setString(2, hashedPassword);
+            try (ResultSet resultSet = pstmt.executeQuery()) {
+                return resultSet.next();
+            }
         }
     }
 
@@ -895,7 +927,8 @@ public class SmartCityApp {
             System.out.println("2. 🏗️ Manage city resources");
             System.out.println("3. 📋 View system logs");
             System.out.println("4. ⚡ Cache statistics");
-            System.out.println("5. 🚪 Logout");
+            System.out.println("5. 🚫 Deactivate a user account");
+            System.out.println("6. 🚪 Logout");
             System.out.print("Enter your choice: ");
 
             int choice = scanner.nextInt();
@@ -917,13 +950,148 @@ public class SmartCityApp {
                     showCacheStats();
                     break;
                 case 5:
+                    // Soft-delete: keep the account and its history, but block logins
+                    deactivateUser();
+                    break;
+                case 6:
                     System.out.println("Logging out from admin account. Goodbye!");
                     inAdminMenu = false;
                     break;
                 default:
-                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 5.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 6.");
             }
         }
+    }
+
+    /**
+     * Deactivates a user account: a soft delete that leaves the row, and
+     * everything attached to it, in place while refusing the account at login.
+     * <p>
+     * Administrators are never listed and never updated — the {@code role !=
+     * 'ADMIN'} guard is repeated in the UPDATE itself, so an admin account
+     * cannot be disabled even if the listing and the update disagree about who
+     * is an admin. The change is confirmed before it is applied.
+     */
+    private static void deactivateUser() {
+        System.out.println("\n--- Deactivate a User Account ---");
+
+        try (Connection connection = getConnectionOrPrintError()) {
+            if (connection == null) {
+                return;
+            }
+
+            List<String> activeUsers = findActiveNonAdminUsernames(connection);
+
+            if (activeUsers.isEmpty()) {
+                System.out.println("ℹ️  There are no active user accounts to deactivate.");
+                pauseUntilEnter();
+                return;
+            }
+
+            System.out.println("\n👥 Active user accounts:");
+            for (String activeUser : activeUsers) {
+                System.out.println("   • " + activeUser);
+            }
+            System.out.println("-".repeat(50));
+
+            System.out.print("Enter username to deactivate: ");
+            String entered = scanner.nextLine().trim();
+
+            if (entered.isEmpty()) {
+                System.out.println("❌ Error: Username cannot be empty. Nothing was changed.");
+                pauseUntilEnter();
+                return;
+            }
+
+            // Resolve what was typed against the list, so the message is accurate
+            // and the UPDATE runs against the username exactly as it is stored.
+            String username = matchIgnoringCase(activeUsers, entered);
+
+            if (username == null) {
+                System.out.println("❌ Error: No active, non-admin account named '" + entered + "' was found.");
+                System.out.println("   Administrators cannot be deactivated, and an account can only be deactivated once.");
+                pauseUntilEnter();
+                return;
+            }
+
+            System.out.print("Are you sure? This will prevent them from logging in. (yes/no): ");
+            String confirmation = scanner.nextLine().trim();
+
+            if (!confirmation.equalsIgnoreCase("yes")) {
+                System.out.println("↩️  Cancelled. '" + username + "' is still active.");
+                pauseUntilEnter();
+                return;
+            }
+
+            try (PreparedStatement pstmt = connection.prepareStatement(DEACTIVATE_USER_QUERY)) {
+                pstmt.setString(1, username);
+
+                int rowsAffected = pstmt.executeUpdate();
+
+                if (rowsAffected > 0) {
+                    System.out.println("✅ User '" + username + "' has been deactivated.");
+                } else {
+                    System.out.println("❌ Error: '" + username + "' could not be deactivated.");
+                    System.out.println("   The account may have been removed or promoted to administrator.");
+                }
+            }
+
+        } catch (SQLException e) {
+            System.out.println("❌ Error: Failed to deactivate the user account.");
+            System.out.println("   Error message: " + e.getMessage());
+        }
+
+        pauseUntilEnter();
+    }
+
+    /**
+     * Reads the usernames of every account that can still be deactivated:
+     * active, and not an administrator.
+     *
+     * @param connection an open database connection
+     * @return the matching usernames in alphabetical order, empty if there are none
+     * @throws SQLException if the query fails
+     */
+    private static List<String> findActiveNonAdminUsernames(Connection connection) throws SQLException {
+        List<String> usernames = new ArrayList<>();
+
+        try (PreparedStatement pstmt = connection.prepareStatement(SELECT_ACTIVE_NON_ADMIN_USERS_QUERY);
+             ResultSet resultSet = pstmt.executeQuery()) {
+
+            while (resultSet.next()) {
+                usernames.add(resultSet.getString("username"));
+            }
+        }
+
+        return usernames;
+    }
+
+    /**
+     * Finds the entry of a list that equals the given text ignoring case.
+     * Used so an admin who types "John" can act on the account stored as
+     * "john", while the stored spelling is what gets used from then on.
+     *
+     * @param candidates the values to search
+     * @param text       the text that was typed
+     * @return the matching entry as stored, or null if nothing matched
+     */
+    private static String matchIgnoringCase(List<String> candidates, String text) {
+        for (String candidate : candidates) {
+            if (candidate.equalsIgnoreCase(text)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Holds the screen until the user presses Enter. The admin menu clears the
+     * terminal as soon as it is redrawn, so without this the outcome of an
+     * action would flash past unread.
+     */
+    private static void pauseUntilEnter() {
+        System.out.print("\nPress Enter to return to the menu... ");
+        scanner.nextLine();
     }
 
     /**
@@ -967,8 +1135,7 @@ public class SmartCityApp {
             System.out.println("🧹 Cache cleared. The next read of every place will go to the database.");
         }
 
-        System.out.print("\nPress Enter to return to the menu... ");
-        scanner.nextLine();
+        pauseUntilEnter();
     }
 
     /**

--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -15,9 +15,10 @@ import java.util.Scanner;
 
 import com.smartcity.db.DBConnection;
 import com.smartcity.model.Place;
+import com.smartcity.service.CacheStats;
+import com.smartcity.service.CachedDBConnection;
 import com.smartcity.service.EmailService;
 import com.smartcity.structures.RecentlyViewedManager;
-import java.util.List;
 import com.smartcity.util.ValidationUtils;
 
 /**
@@ -38,6 +39,9 @@ public class SmartCityApp {
 
     // Recently Viewed Places Manager
     private static final RecentlyViewedManager recentlyViewedManager = new RecentlyViewedManager();
+
+    // Cache-aside layer in front of the database, shared by every place lookup
+    private static final CachedDBConnection cachedDbConnection = new CachedDBConnection();
 
     // SQL Query Constants
     private static final String CHECK_USERNAME_EXISTS_QUERY = "SELECT id FROM users WHERE username = ?";
@@ -890,7 +894,8 @@ public class SmartCityApp {
             System.out.println("1. 👥 View all users");
             System.out.println("2. 🏗️ Manage city resources");
             System.out.println("3. 📋 View system logs");
-            System.out.println("4. 🚪 Logout");
+            System.out.println("4. ⚡ Cache statistics");
+            System.out.println("5. 🚪 Logout");
             System.out.print("Enter your choice: ");
 
             int choice = scanner.nextInt();
@@ -908,13 +913,62 @@ public class SmartCityApp {
                     System.out.println("Displaying system logs...");
                     break;
                 case 4:
+                    // Inspect (and optionally flush) the in-memory cache
+                    showCacheStats();
+                    break;
+                case 5:
                     System.out.println("Logging out from admin account. Goodbye!");
                     inAdminMenu = false;
                     break;
                 default:
-                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 4.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 5.");
             }
         }
+    }
+
+    /**
+     * Prints how the in-memory cache layer has been performing this session —
+     * hits, misses, hit rate, expiries, invalidations, and how much is
+     * currently held — then offers to flush it.
+     * <p>
+     * The numbers are the ones an admin needs to answer "is the cache actually
+     * saving us queries?": a hit rate climbing towards 100% means repeat views
+     * are being served from memory, while a run of misses means entries are
+     * expiring (or being invalidated) faster than they are being reused.
+     */
+    private static void showCacheStats() {
+        CacheStats stats = cachedDbConnection.getCacheStats();
+
+        System.out.println();
+        System.out.println("╔" + "═".repeat(STATS_BOX_WIDTH) + "╗");
+        System.out.println(centeredStatsRow("⚡  CACHE PERFORMANCE"));
+        System.out.println("╠" + "═".repeat(STATS_BOX_WIDTH) + "╣");
+        System.out.println(statsRow("✅", "Cache hits", String.valueOf(stats.getHits())));
+        System.out.println(statsRow("❌", "Cache misses", String.valueOf(stats.getMisses())));
+        System.out.println(statsRow("🎯", "Hit rate", String.format("%.1f%%", stats.getHitRatio() * 100)));
+        System.out.println(statsRow("🔢", "Total lookups", String.valueOf(stats.getTotalLookups())));
+        System.out.println("╟" + "─".repeat(STATS_BOX_WIDTH) + "╢");
+        System.out.println(statsRow("⏳", "Expired entries", String.valueOf(stats.getExpirations())));
+        System.out.println(statsRow("🧹", "Invalidations", String.valueOf(stats.getInvalidations())));
+        System.out.println("╟" + "─".repeat(STATS_BOX_WIDTH) + "╢");
+        System.out.println(statsRow("🏙️", "Places cached", String.valueOf(stats.getPlaceEntries())));
+        System.out.println(statsRow("👥", "Users cached", String.valueOf(stats.getUserEntries())));
+        System.out.println(statsRow("⌛", "Entry TTL", (cachedDbConnection.getTtlMillis() / 1000) + " s"));
+        System.out.println("╚" + "═".repeat(STATS_BOX_WIDTH) + "╝");
+
+        if (stats.getTotalLookups() == 0) {
+            System.out.println("\nℹ️  No lookups yet — view a place twice to see a miss followed by a hit.");
+        }
+
+        System.out.print("\nClear the cache now? (y/N): ");
+        String answer = scanner.nextLine();
+        if (answer != null && answer.trim().equalsIgnoreCase("y")) {
+            cachedDbConnection.clearCache();
+            System.out.println("🧹 Cache cleared. The next read of every place will go to the database.");
+        }
+
+        System.out.print("\nPress Enter to return to the menu... ");
+        scanner.nextLine();
     }
 
     /**
@@ -979,8 +1033,13 @@ public class SmartCityApp {
     }
 
     /**
-     * Prompts the user for a place ID, fetches its details from the database,
-     * prints them, and records the view in the RecentlyViewedManager.
+     * Prompts the user for a place ID, fetches its details through the cache
+     * layer, prints them along with where the data came from and how long the
+     * lookup took, and records the view in the RecentlyViewedManager.
+     * <p>
+     * Looking the same place up twice in a row is the clearest demonstration of
+     * the cache-aside pattern: the first read pays for a database round trip,
+     * every read after it is answered from memory until the TTL elapses.
      */
     private static void viewPlaceDetails() {
         System.out.print("\nEnter place ID to view details: ");
@@ -994,39 +1053,57 @@ public class SmartCityApp {
             return;
         }
 
-        try (Connection connection = getConnectionOrPrintError()) {
-            if (connection == null) {
-                return;
-            }
+        // Asked before the lookup, since the lookup itself populates the cache.
+        boolean servedFromCache = cachedDbConnection.isPlaceCached(placeId);
 
-            try (PreparedStatement pstmt = connection.prepareStatement(SELECT_PLACE_BY_ID_QUERY)) {
-                pstmt.setInt(1, placeId);
-                try (ResultSet rs = pstmt.executeQuery()) {
-                    if (rs.next()) {
-                        System.out.println("\n📖 ===== PLACE DETAILS =====");
-                        System.out.println("📍 Place ID: " + rs.getInt("id"));
-                        System.out.println("   Name: " + rs.getString("name"));
-                        System.out.println("   Category: " + rs.getString("category"));
-                        System.out.println("   Location: " + rs.getString("location"));
-                        System.out.println("   Description: " + rs.getString("description"));
-                        System.out.println("   Coordinates: " + rs.getDouble("latitude") + ", " + rs.getDouble("longitude"));
-                        System.out.println("-".repeat(50));
-                        
-                        // Record view
-                        recentlyViewedManager.viewPlace(placeId);
-                    } else {
-                        System.out.println("❌ Error: Place with ID " + placeId + " not found.");
-                    }
-                }
-            }
-        } catch (SQLException e) {
-            System.out.println("❌ Error: Failed to fetch place details.");
-            System.out.println("   Error message: " + e.getMessage());
+        long startNanos = System.nanoTime();
+        Place place = cachedDbConnection.getPlace(placeId);
+        double elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000.0;
+
+        if (place == null) {
+            // A miss that returns nothing means either no such row or an
+            // unreachable database, so the message covers both.
+            System.out.println("❌ Error: Place with ID " + placeId + " could not be loaded.");
+            System.out.println("   It may not exist, or the database may be unavailable.");
+            return;
         }
+
+        System.out.println("\n📖 ===== PLACE DETAILS =====");
+        System.out.println("📍 Place ID: " + place.getId());
+        System.out.println("   Name: " + place.getName());
+        System.out.println("   Category: " + place.getCategory());
+        System.out.println("   Location: " + place.getLocation());
+        System.out.println("   Description: " + place.getDescription());
+        System.out.println("   Coordinates: " + place.getLatitude() + ", " + place.getLongitude());
+        System.out.println(cacheSourceLine(servedFromCache, elapsedMillis));
+        System.out.println("   " + cachedDbConnection.getCacheStats());
+        System.out.println("-".repeat(50));
+
+        // Record view
+        recentlyViewedManager.viewPlace(placeId);
+    }
+
+    /**
+     * Builds the one-line note that tells the user whether a lookup was served
+     * from the in-memory cache or from the database, and how long it took.
+     *
+     * @param servedFromCache true if the value was already cached when the
+     *                        lookup started
+     * @param elapsedMillis   how long the lookup took, in milliseconds
+     * @return a formatted line ready to print
+     */
+    private static String cacheSourceLine(boolean servedFromCache, double elapsedMillis) {
+        String source = servedFromCache
+                ? "⚡ Cache HIT  — served from memory"
+                : "🐢 Cache MISS — read from the database";
+        return String.format("   %s in %.3f ms", source, elapsedMillis);
     }
 
     /**
      * Fetches the recently viewed places from the manager and displays them.
+     * <p>
+     * Every place in this list has just been viewed, so the lookups go through
+     * the cache and are normally answered from memory without a single query.
      */
     private static void viewRecentlyViewedPlaces() {
         List<Integer> recentIds = recentlyViewedManager.getRecent();
@@ -1038,28 +1115,21 @@ public class SmartCityApp {
         System.out.println("\n🕒 ===== RECENTLY VIEWED PLACES =====");
         System.out.println("-".repeat(50));
 
-        try (Connection connection = getConnectionOrPrintError()) {
-            if (connection == null) {
-                return;
-            }
+        CacheStats before = cachedDbConnection.getCacheStats();
 
-            try (PreparedStatement pstmt = connection.prepareStatement(SELECT_PLACE_BY_ID_QUERY)) {
-                for (int id : recentIds) {
-                    pstmt.setInt(1, id);
-                    try (ResultSet rs = pstmt.executeQuery()) {
-                        if (rs.next()) {
-                            System.out.println("📍 Place ID: " + rs.getInt("id"));
-                            System.out.println("   Name: " + rs.getString("name"));
-                            System.out.println("   Category: " + rs.getString("category"));
-                            System.out.println("");
-                        }
-                    }
-                }
+        for (int id : recentIds) {
+            Place place = cachedDbConnection.getPlace(id);
+            if (place != null) {
+                System.out.println("📍 Place ID: " + place.getId());
+                System.out.println("   Name: " + place.getName());
+                System.out.println("   Category: " + place.getCategory());
+                System.out.println("");
             }
-        } catch (SQLException e) {
-            System.out.println("❌ Error: Failed to fetch recently viewed places.");
-            System.out.println("   Error message: " + e.getMessage());
         }
+
+        CacheStats after = cachedDbConnection.getCacheStats();
+        System.out.println("⚡ " + (after.getHits() - before.getHits()) + " of " + recentIds.size()
+                + " lookups served from cache.");
         System.out.println("-".repeat(50));
     }
 
@@ -1395,6 +1465,9 @@ public class SmartCityApp {
                 int rowsAffected = pstmt.executeUpdate();
 
                 if (rowsAffected > 0) {
+                    // An earlier failed lookup may have left nothing cached, but drop
+                    // the key anyway so the new row can never be shadowed.
+                    cachedDbConnection.invalidatePlace(id);
                     System.out.println("✅ Success! Place '" + name + "' has been added to the city.");
                 } else {
                     System.out.println("❌ Error: Failed to add place. Please try again.");
@@ -1547,6 +1620,8 @@ public class SmartCityApp {
                 int rows = updatePstmt.executeUpdate();
 
                 if (rows > 0) {
+                    // The cached copy is now stale — evict it so the next read reloads.
+                    cachedDbConnection.invalidatePlace(placeId);
                     System.out.println("✅ Success! Place updated successfully.");
                 } else {
                     System.out.println("❌ Error: Update failed.");
@@ -1589,6 +1664,8 @@ public class SmartCityApp {
                 int rowsAffected = pstmt.executeUpdate();
 
                 if (rowsAffected > 0) {
+                    // The row is gone; the cached copy must go with it.
+                    cachedDbConnection.invalidatePlace(placeId);
                     System.out.println("✅ Success! Place with ID " + placeId + " has been deleted.");
                 } else {
                     System.out.println("❌ Error: Place with ID " + placeId + " not found.");

--- a/src/com/smartcity/service/CacheStats.java
+++ b/src/com/smartcity/service/CacheStats.java
@@ -1,0 +1,137 @@
+package com.smartcity.service;
+
+/**
+ * An immutable snapshot of a {@link CachedDBConnection}'s counters, taken at
+ * the moment {@link CachedDBConnection#getCacheStats()} is called.
+ * <p>
+ * Because it is a snapshot rather than a live view, two snapshots taken at
+ * different times can be compared to measure a single operation, and holding
+ * one never exposes the cache's internal counters to modification.
+ * <p>
+ * Time Complexity: O(1) for every accessor.
+ * Space Complexity: O(1).
+ *
+ * @author SmartCityApp contributors
+ * @version 1.0
+ */
+public final class CacheStats {
+
+    private final long hits;
+    private final long misses;
+    private final long expirations;
+    private final long invalidations;
+    private final int placeEntries;
+    private final int userEntries;
+
+    /**
+     * Constructs a snapshot of the cache counters.
+     *
+     * @param hits          number of lookups served from the cache
+     * @param misses        number of lookups that had to fall through to the database
+     * @param expirations   number of entries dropped because their TTL had elapsed
+     * @param invalidations number of entries evicted explicitly after a data modification
+     * @param placeEntries  number of place entries currently held (expired ones included)
+     * @param userEntries   number of user entries currently held (expired ones included)
+     */
+    public CacheStats(long hits, long misses, long expirations, long invalidations,
+                      int placeEntries, int userEntries) {
+        this.hits = hits;
+        this.misses = misses;
+        this.expirations = expirations;
+        this.invalidations = invalidations;
+        this.placeEntries = placeEntries;
+        this.userEntries = userEntries;
+    }
+
+    /**
+     * Gets the number of lookups answered from the cache without touching the database.
+     *
+     * @return the hit count
+     */
+    public long getHits() {
+        return hits;
+    }
+
+    /**
+     * Gets the number of lookups that fell through to the database, whether because the
+     * key was absent or because the cached entry had expired.
+     *
+     * @return the miss count
+     */
+    public long getMisses() {
+        return misses;
+    }
+
+    /**
+     * Gets the number of cached entries that were found expired and discarded.
+     * Every expiration also counts as a miss.
+     *
+     * @return the expiration count
+     */
+    public long getExpirations() {
+        return expirations;
+    }
+
+    /**
+     * Gets the number of entries evicted explicitly, either by a targeted
+     * invalidation after a data modification or by {@link CachedDBConnection#clearCache()}.
+     *
+     * @return the invalidation count
+     */
+    public long getInvalidations() {
+        return invalidations;
+    }
+
+    /**
+     * Gets the number of place entries currently held in the cache. Entries whose TTL
+     * has elapsed are still counted until the next lookup evicts them.
+     *
+     * @return the number of cached places
+     */
+    public int getPlaceEntries() {
+        return placeEntries;
+    }
+
+    /**
+     * Gets the number of user entries currently held in the cache. Entries whose TTL
+     * has elapsed are still counted until the next lookup evicts them.
+     *
+     * @return the number of cached users
+     */
+    public int getUserEntries() {
+        return userEntries;
+    }
+
+    /**
+     * Gets the total number of lookups performed, which is hits plus misses.
+     *
+     * @return the total lookup count
+     */
+    public long getTotalLookups() {
+        return hits + misses;
+    }
+
+    /**
+     * Calculates the fraction of lookups served from the cache.
+     *
+     * @return a value between 0.0 and 1.0, or 0.0 when no lookup has happened yet
+     */
+    public double getHitRatio() {
+        long total = getTotalLookups();
+        if (total == 0) {
+            return 0.0;
+        }
+        return (double) hits / total;
+    }
+
+    /**
+     * Returns a one-line, human-readable summary of the counters.
+     *
+     * @return a formatted summary such as {@code "Cache Stats: 3 hits, 1 misses (75.00% hit rate), 2 entries cached"}
+     */
+    @Override
+    public String toString() {
+        return String.format("Cache Stats: %d hits, %d misses (%.2f%% hit rate), %d entries cached",
+                hits, misses, getHitRatio() * 100, placeEntries + userEntries);
+    }
+}

--- a/src/com/smartcity/service/CachedDBConnection.java
+++ b/src/com/smartcity/service/CachedDBConnection.java
@@ -1,0 +1,406 @@
+package com.smartcity.service;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+import com.smartcity.db.DBConnection;
+import com.smartcity.model.Place;
+import com.smartcity.model.User;
+
+/**
+ * An in-memory read cache that sits in front of {@link DBConnection} and follows the
+ * cache-aside pattern: a lookup first consults a {@link HashMap}, and only on a miss
+ * does it query the database and store what it found for next time.
+ * <p>
+ * Every cached value carries an expiry stamp, so an entry that has outlived its
+ * time-to-live (TTL) is treated as absent and refreshed from the database on the next
+ * lookup. Writes are never cached — after a place is added, updated, or deleted the
+ * caller invalidates the affected key via {@link #invalidatePlace(int)} so the next
+ * read sees the new row rather than a stale one.
+ * <p>
+ * Time Complexity:
+ *   - Cache hit: O(1) HashMap lookup
+ *   - Cache miss: O(1) plus the cost of one database query
+ *   - invalidate / clear (per entry): O(1)
+ * Space Complexity: O(n), where n is the number of cached entries. The cache is
+ * unbounded by design; entries leave only through expiry or invalidation.
+ * <p>
+ * This class is deliberately <em>not</em> thread-safe: it backs a single-threaded CLI
+ * and uses plain {@link HashMap}s. Sharing an instance across threads would need
+ * external synchronisation or a {@code ConcurrentHashMap}.
+ * <p>
+ * Related Learning: LeetCode 146 "LRU Cache", LeetCode 706 "Design HashMap",
+ *                   Cache-Aside Pattern
+ *
+ * @author SmartCityApp contributors
+ * @version 1.0
+ */
+public class CachedDBConnection {
+
+    /** Default time-to-live applied to cached entries: five minutes. */
+    public static final long DEFAULT_TTL_MILLIS = 5 * 60 * 1000L;
+
+    private static final String SELECT_PLACE_BY_ID_QUERY = "SELECT * FROM places WHERE id = ?";
+    private static final String SELECT_USER_BY_ID_QUERY = "SELECT username, password, role FROM users WHERE id = ?";
+
+    private final Map<Integer, CacheEntry<Place>> placeCache = new HashMap<>();
+    private final Map<Integer, CacheEntry<User>> userCache = new HashMap<>();
+
+    private final long ttlMillis;
+    private final PlaceLoader placeLoader;
+    private final UserLoader userLoader;
+    private final LongSupplier clock;
+
+    private long hits;
+    private long misses;
+    private long expirations;
+    private long invalidations;
+
+    /**
+     * Loads a place from the underlying store when the cache cannot answer a lookup.
+     */
+    @FunctionalInterface
+    public interface PlaceLoader {
+        /**
+         * Fetches a single place by ID.
+         *
+         * @param placeId the ID of the place to load
+         * @return the place, or {@code null} if no such place exists or the load failed
+         */
+        Place load(int placeId);
+    }
+
+    /**
+     * Loads a user from the underlying store when the cache cannot answer a lookup.
+     */
+    @FunctionalInterface
+    public interface UserLoader {
+        /**
+         * Fetches a single user by ID.
+         *
+         * @param userId the ID of the user to load
+         * @return the user, or {@code null} if no such user exists or the load failed
+         */
+        User load(int userId);
+    }
+
+    /**
+     * Creates a cache in front of the application database using the default
+     * five-minute TTL.
+     */
+    public CachedDBConnection() {
+        this(DEFAULT_TTL_MILLIS);
+    }
+
+    /**
+     * Creates a cache in front of the application database with a custom TTL.
+     *
+     * @param ttlMillis how long a cached entry stays fresh, in milliseconds
+     * @throws IllegalArgumentException if {@code ttlMillis} is not positive
+     */
+    public CachedDBConnection(long ttlMillis) {
+        this(ttlMillis,
+                CachedDBConnection::loadPlaceFromDatabase,
+                CachedDBConnection::loadUserFromDatabase);
+    }
+
+    /**
+     * Creates a cache in front of arbitrary loaders. Useful for tests and for any
+     * caller that reads places and users from somewhere other than the default
+     * database queries.
+     *
+     * @param ttlMillis   how long a cached entry stays fresh, in milliseconds
+     * @param placeLoader supplies places on a cache miss
+     * @param userLoader  supplies users on a cache miss
+     * @throws IllegalArgumentException if {@code ttlMillis} is not positive
+     * @throws NullPointerException     if either loader is {@code null}
+     */
+    public CachedDBConnection(long ttlMillis, PlaceLoader placeLoader, UserLoader userLoader) {
+        this(ttlMillis, placeLoader, userLoader, System::currentTimeMillis);
+    }
+
+    /**
+     * Creates a cache with an injectable clock, so TTL expiry can be exercised in tests
+     * without sleeping.
+     *
+     * @param ttlMillis   how long a cached entry stays fresh, in milliseconds
+     * @param placeLoader supplies places on a cache miss
+     * @param userLoader  supplies users on a cache miss
+     * @param clock       source of the current time in milliseconds
+     * @throws IllegalArgumentException if {@code ttlMillis} is not positive
+     * @throws NullPointerException     if any loader or the clock is {@code null}
+     */
+    public CachedDBConnection(long ttlMillis, PlaceLoader placeLoader, UserLoader userLoader, LongSupplier clock) {
+        if (ttlMillis <= 0) {
+            throw new IllegalArgumentException("TTL must be positive, but was " + ttlMillis + " ms.");
+        }
+        if (placeLoader == null || userLoader == null) {
+            throw new NullPointerException("Place and user loaders must not be null.");
+        }
+        if (clock == null) {
+            throw new NullPointerException("Clock must not be null.");
+        }
+        this.ttlMillis = ttlMillis;
+        this.placeLoader = placeLoader;
+        this.userLoader = userLoader;
+        this.clock = clock;
+    }
+
+    /**
+     * Returns the place with the given ID, serving it from the cache when a fresh copy
+     * is held and otherwise loading it from the database and caching the result.
+     * <p>
+     * A lookup that finds nothing is not cached, so a place created later is picked up
+     * on the next call rather than being masked by a cached {@code null}.
+     *
+     * @param placeId the ID of the place to fetch
+     * @return the place, or {@code null} if it does not exist or could not be loaded
+     */
+    public Place getPlace(int placeId) {
+        CacheEntry<Place> entry = placeCache.get(placeId);
+
+        if (entry != null) {
+            if (!entry.isExpired(now())) {
+                hits++;
+                return entry.getValue();
+            }
+            // The entry outlived its TTL: drop it and fall through to the database.
+            placeCache.remove(placeId);
+            expirations++;
+        }
+
+        misses++;
+        Place place = placeLoader.load(placeId);
+        if (place != null) {
+            placeCache.put(placeId, new CacheEntry<>(place, now() + ttlMillis));
+        }
+        return place;
+    }
+
+    /**
+     * Returns the user with the given ID, serving it from the cache when a fresh copy
+     * is held and otherwise loading it from the database and caching the result.
+     * <p>
+     * As with places, a lookup that finds nothing is not cached.
+     *
+     * @param userId the ID of the user to fetch
+     * @return the user, or {@code null} if it does not exist or could not be loaded
+     */
+    public User getUser(int userId) {
+        CacheEntry<User> entry = userCache.get(userId);
+
+        if (entry != null) {
+            if (!entry.isExpired(now())) {
+                hits++;
+                return entry.getValue();
+            }
+            userCache.remove(userId);
+            expirations++;
+        }
+
+        misses++;
+        User user = userLoader.load(userId);
+        if (user != null) {
+            userCache.put(userId, new CacheEntry<>(user, now() + ttlMillis));
+        }
+        return user;
+    }
+
+    /**
+     * Reports whether a fresh copy of a place is cached, without counting the check as
+     * a hit or a miss. Intended for display code that wants to say where a value came
+     * from before asking for it.
+     *
+     * @param placeId the ID to check
+     * @return true if the next {@link #getPlace(int)} would be served from the cache
+     */
+    public boolean isPlaceCached(int placeId) {
+        CacheEntry<Place> entry = placeCache.get(placeId);
+        return entry != null && !entry.isExpired(now());
+    }
+
+    /**
+     * Reports whether a fresh copy of a user is cached, without counting the check as
+     * a hit or a miss.
+     *
+     * @param userId the ID to check
+     * @return true if the next {@link #getUser(int)} would be served from the cache
+     */
+    public boolean isUserCached(int userId) {
+        CacheEntry<User> entry = userCache.get(userId);
+        return entry != null && !entry.isExpired(now());
+    }
+
+    /**
+     * Drops the cached copy of a place. Call this straight after a place is added,
+     * updated, or deleted so the next read reflects the change instead of a stale row.
+     *
+     * @param placeId the ID whose cached copy should be discarded
+     * @return true if an entry was actually removed
+     */
+    public boolean invalidatePlace(int placeId) {
+        if (placeCache.remove(placeId) != null) {
+            invalidations++;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Drops the cached copy of a user. Call this after a user's details change.
+     *
+     * @param userId the ID whose cached copy should be discarded
+     * @return true if an entry was actually removed
+     */
+    public boolean invalidateUser(int userId) {
+        if (userCache.remove(userId) != null) {
+            invalidations++;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Empties both caches, counting every discarded entry as an invalidation. Hit and
+     * miss totals are left untouched, so the metrics gathered so far survive a flush;
+     * use {@link #resetStats()} to zero those as well.
+     */
+    public void clearCache() {
+        invalidations += placeCache.size() + userCache.size();
+        placeCache.clear();
+        userCache.clear();
+    }
+
+    /**
+     * Zeroes the hit, miss, expiration, and invalidation counters, leaving the cached
+     * entries themselves in place. Handy for measuring one demo run in isolation.
+     */
+    public void resetStats() {
+        hits = 0;
+        misses = 0;
+        expirations = 0;
+        invalidations = 0;
+    }
+
+    /**
+     * Takes a snapshot of the current cache metrics.
+     *
+     * @return an immutable {@link CacheStats} describing the cache as it stands now
+     */
+    public CacheStats getCacheStats() {
+        return new CacheStats(hits, misses, expirations, invalidations,
+                placeCache.size(), userCache.size());
+    }
+
+    /**
+     * Gets the time-to-live applied to entries written by this cache.
+     *
+     * @return the TTL in milliseconds
+     */
+    public long getTtlMillis() {
+        return ttlMillis;
+    }
+
+    private long now() {
+        return clock.getAsLong();
+    }
+
+    /**
+     * Reads one place row from the application database. Returns {@code null} — rather
+     * than throwing — when the place is missing or the database is unreachable, so a
+     * failed load degrades into an ordinary "not found" for the caller.
+     *
+     * @param placeId the ID of the place to read
+     * @return the place, or {@code null} if it does not exist or the query failed
+     */
+    private static Place loadPlaceFromDatabase(int placeId) {
+        try (Connection connection = DBConnection.getConnection()) {
+            if (connection == null) {
+                return null;
+            }
+
+            try (PreparedStatement pstmt = connection.prepareStatement(SELECT_PLACE_BY_ID_QUERY)) {
+                pstmt.setInt(1, placeId);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    return new Place(
+                            rs.getInt("id"),
+                            rs.getString("name"),
+                            rs.getString("category"),
+                            rs.getString("location"),
+                            rs.getString("description"),
+                            rs.getDouble("latitude"),
+                            rs.getDouble("longitude"));
+                }
+            }
+        } catch (SQLException e) {
+            System.out.println("❌ Error: Failed to load place " + placeId + " from database.");
+            System.out.println("   Error message: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Reads one user row from the application database. Returns {@code null} when the
+     * user is missing or the database is unreachable.
+     *
+     * @param userId the ID of the user to read
+     * @return the user, or {@code null} if it does not exist or the query failed
+     */
+    private static User loadUserFromDatabase(int userId) {
+        try (Connection connection = DBConnection.getConnection()) {
+            if (connection == null) {
+                return null;
+            }
+
+            try (PreparedStatement pstmt = connection.prepareStatement(SELECT_USER_BY_ID_QUERY)) {
+                pstmt.setInt(1, userId);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    User user = new User(rs.getString("username"), rs.getString("password"));
+                    String role = rs.getString("role");
+                    if (role != null && !role.isEmpty()) {
+                        user.setRole(role);
+                    }
+                    return user;
+                }
+            }
+        } catch (SQLException e) {
+            System.out.println("❌ Error: Failed to load user " + userId + " from database.");
+            System.out.println("   Error message: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * A cached value paired with the instant it stops being fresh.
+     *
+     * @param <T> the type of the cached value
+     */
+    private static final class CacheEntry<T> {
+        private final T value;
+        private final long expiresAt;
+
+        CacheEntry(T value, long expiresAt) {
+            this.value = value;
+            this.expiresAt = expiresAt;
+        }
+
+        T getValue() {
+            return value;
+        }
+
+        boolean isExpired(long currentTimeMillis) {
+            return currentTimeMillis >= expiresAt;
+        }
+    }
+}

--- a/tests/com/smartcity/service/CacheStatsTest.java
+++ b/tests/com/smartcity/service/CacheStatsTest.java
@@ -1,0 +1,69 @@
+/*
+ * How to run these tests:
+ *
+ *   mvn test                          # run the whole test suite
+ *   mvn test -Dtest=CacheStatsTest    # run only this class
+ *
+ * Requires JDK 21 and Maven. No database connection is needed.
+ */
+package com.smartcity.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CacheStats}.
+ *
+ * <p>The derived figures — total lookups and hit rate — are what the CLI puts
+ * in front of an admin, so they are pinned down here independently of the
+ * cache that produces them.
+ */
+class CacheStatsTest {
+
+    @Test
+    @DisplayName("every counter is reported back exactly as it was supplied")
+    void gettersShouldReturnConstructorValues() {
+        CacheStats stats = new CacheStats(9, 3, 2, 1, 5, 4);
+
+        assertEquals(9, stats.getHits());
+        assertEquals(3, stats.getMisses());
+        assertEquals(2, stats.getExpirations());
+        assertEquals(1, stats.getInvalidations());
+        assertEquals(5, stats.getPlaceEntries());
+        assertEquals(4, stats.getUserEntries());
+    }
+
+    @Test
+    @DisplayName("total lookups is hits plus misses")
+    void totalLookupsShouldSumHitsAndMisses() {
+        assertEquals(12, new CacheStats(9, 3, 0, 0, 0, 0).getTotalLookups());
+    }
+
+    @Test
+    @DisplayName("the hit rate is the share of lookups served from memory")
+    void hitRatioShouldBeHitsOverTotal() {
+        assertEquals(0.75, new CacheStats(3, 1, 0, 0, 0, 0).getHitRatio(), 1e-9);
+        assertEquals(1.0, new CacheStats(4, 0, 0, 0, 0, 0).getHitRatio(), 1e-9);
+        assertEquals(0.0, new CacheStats(0, 4, 0, 0, 0, 0).getHitRatio(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("an idle cache reports a zero hit rate rather than dividing by zero")
+    void hitRatioShouldBeZeroWhenNothingHappened() {
+        assertEquals(0.0, new CacheStats(0, 0, 0, 0, 0, 0).getHitRatio(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("toString summarises hits, misses, hit rate, and how much is cached")
+    void toStringShouldSummariseTheCounters() {
+        String summary = new CacheStats(3, 1, 0, 0, 2, 1).toString();
+
+        assertTrue(summary.contains("3 hits"), summary);
+        assertTrue(summary.contains("1 misses"), summary);
+        assertTrue(summary.contains("75.00%"), summary);
+        assertTrue(summary.contains("3 entries cached"), summary);
+    }
+}

--- a/tests/com/smartcity/service/CachedDBConnectionTest.java
+++ b/tests/com/smartcity/service/CachedDBConnectionTest.java
@@ -1,0 +1,567 @@
+/*
+ * How to run these tests:
+ *
+ *   mvn test                                   # run the whole test suite
+ *   mvn test -Dtest=CachedDBConnectionTest     # run only this class
+ *
+ * Requires JDK 21 and Maven. No database connection is needed: every test
+ * drives the cache through in-memory loaders and a fake clock, so TTL expiry
+ * is exercised without a single Thread.sleep.
+ */
+package com.smartcity.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.smartcity.model.Place;
+import com.smartcity.model.User;
+
+/**
+ * Unit tests for {@link CachedDBConnection}.
+ *
+ * <p>These pin down the cache-aside contract: what is served from memory, what
+ * falls through to the loader, when an entry stops being fresh, and what the
+ * reported metrics mean. A future change that quietly stops invalidating on a
+ * write, or that starts caching "not found", will fail here.
+ */
+class CachedDBConnectionTest {
+
+    private static final long TTL_MILLIS = 1_000L;
+
+    private CountingPlaceLoader placeLoader;
+    private CountingUserLoader userLoader;
+    private MutableClock clock;
+    private CachedDBConnection cache;
+
+    @BeforeEach
+    void setUp() {
+        placeLoader = new CountingPlaceLoader();
+        userLoader = new CountingUserLoader();
+        clock = new MutableClock(0L);
+        cache = new CachedDBConnection(TTL_MILLIS, placeLoader, userLoader, clock);
+
+        placeLoader.store(place(1, "City Museum"));
+        placeLoader.store(place(2, "Riverside Park"));
+        userLoader.store(7, user("alice"));
+        userLoader.store(8, user("bob"));
+    }
+
+    @Nested
+    @DisplayName("cache misses")
+    class Misses {
+
+        @Test
+        @DisplayName("the first lookup of a place goes to the loader and is recorded as a miss")
+        void firstPlaceLookup_shouldMissAndLoad() {
+            Place loaded = cache.getPlace(1);
+
+            assertNotNull(loaded);
+            assertEquals("City Museum", loaded.getName());
+            assertEquals(1, placeLoader.callCount(), "the loader should have been consulted once");
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getHits());
+            assertEquals(1, stats.getMisses());
+            assertEquals(1, stats.getPlaceEntries(), "the loaded place should now be cached");
+        }
+
+        @Test
+        @DisplayName("the first lookup of a user goes to the loader and is recorded as a miss")
+        void firstUserLookup_shouldMissAndLoad() {
+            User loaded = cache.getUser(7);
+
+            assertNotNull(loaded);
+            assertEquals("alice", loaded.getUsername());
+            assertEquals(1, userLoader.callCount());
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getHits());
+            assertEquals(1, stats.getMisses());
+            assertEquals(1, stats.getUserEntries());
+        }
+
+        @Test
+        @DisplayName("a place that does not exist returns null and is never cached")
+        void unknownPlace_shouldNotBeCached() {
+            assertNull(cache.getPlace(404));
+            assertNull(cache.getPlace(404));
+
+            assertEquals(2, placeLoader.callCount(), "a missing row must be retried, not remembered");
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getHits());
+            assertEquals(2, stats.getMisses());
+            assertEquals(0, stats.getPlaceEntries());
+        }
+
+        @Test
+        @DisplayName("a row created after a failed lookup is picked up on the next read")
+        void placeAddedAfterMiss_shouldBeVisible() {
+            assertNull(cache.getPlace(3));
+
+            placeLoader.store(place(3, "Harbour Lights"));
+
+            Place loaded = cache.getPlace(3);
+            assertNotNull(loaded, "a cached null would have hidden the new row");
+            assertEquals("Harbour Lights", loaded.getName());
+        }
+
+        @Test
+        @DisplayName("a user that does not exist returns null and is never cached")
+        void unknownUser_shouldNotBeCached() {
+            assertNull(cache.getUser(404));
+            assertNull(cache.getUser(404));
+
+            assertEquals(2, userLoader.callCount());
+            assertEquals(0, cache.getCacheStats().getUserEntries());
+        }
+    }
+
+    @Nested
+    @DisplayName("cache hits")
+    class Hits {
+
+        @Test
+        @DisplayName("a repeated place lookup is served from memory without touching the loader")
+        void repeatedPlaceLookup_shouldHit() {
+            Place first = cache.getPlace(1);
+            Place second = cache.getPlace(1);
+
+            assertSame(first, second, "a hit should return the very object that was cached");
+            assertEquals(1, placeLoader.callCount(), "the loader must not be consulted a second time");
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(1, stats.getHits());
+            assertEquals(1, stats.getMisses());
+        }
+
+        @Test
+        @DisplayName("a repeated user lookup is served from memory without touching the loader")
+        void repeatedUserLookup_shouldHit() {
+            User first = cache.getUser(7);
+            User second = cache.getUser(7);
+
+            assertSame(first, second);
+            assertEquals(1, userLoader.callCount());
+            assertEquals(1, cache.getCacheStats().getHits());
+        }
+
+        @Test
+        @DisplayName("places and users with the same ID are cached independently")
+        void placeAndUserKeys_shouldNotCollide() {
+            placeLoader.store(place(7, "Seven Sisters"));
+
+            Place cachedPlace = cache.getPlace(7);
+            User cachedUser = cache.getUser(7);
+
+            assertEquals("Seven Sisters", cachedPlace.getName());
+            assertEquals("alice", cachedUser.getUsername());
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(1, stats.getPlaceEntries());
+            assertEquals(1, stats.getUserEntries());
+        }
+
+        @Test
+        @DisplayName("the hit rate rises as the same place is read again and again")
+        void hitRatio_shouldReflectRepeatedReads() {
+            cache.getPlace(1);
+            cache.getPlace(1);
+            cache.getPlace(1);
+            cache.getPlace(1);
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(3, stats.getHits());
+            assertEquals(1, stats.getMisses());
+            assertEquals(4, stats.getTotalLookups());
+            assertEquals(0.75, stats.getHitRatio(), 1e-9);
+        }
+    }
+
+    @Nested
+    @DisplayName("TTL expiration")
+    class Expiration {
+
+        @Test
+        @DisplayName("an entry stays fresh for the whole TTL window")
+        void justBeforeExpiry_shouldStillHit() {
+            cache.getPlace(1);
+            clock.advance(TTL_MILLIS - 1);
+
+            cache.getPlace(1);
+
+            assertEquals(1, placeLoader.callCount(), "the entry should not have expired yet");
+            assertEquals(1, cache.getCacheStats().getHits());
+        }
+
+        @Test
+        @DisplayName("once the TTL elapses the entry is discarded and reloaded")
+        void afterExpiry_shouldMissAndReload() {
+            cache.getPlace(1);
+            clock.advance(TTL_MILLIS);
+
+            cache.getPlace(1);
+
+            assertEquals(2, placeLoader.callCount(), "an expired entry must be reloaded");
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getHits());
+            assertEquals(2, stats.getMisses());
+            assertEquals(1, stats.getExpirations());
+        }
+
+        @Test
+        @DisplayName("an expired entry serves the current data, not the stale copy")
+        void afterExpiry_shouldServeFreshData() {
+            assertEquals("City Museum", cache.getPlace(1).getName());
+
+            placeLoader.store(place(1, "City Museum (renovated)"));
+            clock.advance(TTL_MILLIS + 1);
+
+            assertEquals("City Museum (renovated)", cache.getPlace(1).getName());
+        }
+
+        @Test
+        @DisplayName("the reloaded entry gets a fresh TTL window of its own")
+        void reloadedEntry_shouldGetANewWindow() {
+            cache.getPlace(1);
+            clock.advance(TTL_MILLIS);
+            cache.getPlace(1);
+
+            clock.advance(TTL_MILLIS - 1);
+            cache.getPlace(1);
+
+            assertEquals(2, placeLoader.callCount(), "the refreshed entry should still be fresh");
+            assertEquals(1, cache.getCacheStats().getHits());
+        }
+
+        @Test
+        @DisplayName("user entries expire on the same terms as place entries")
+        void users_shouldExpireToo() {
+            cache.getUser(7);
+            clock.advance(TTL_MILLIS + 1);
+            cache.getUser(7);
+
+            assertEquals(2, userLoader.callCount());
+            assertEquals(1, cache.getCacheStats().getExpirations());
+        }
+
+        @Test
+        @DisplayName("isPlaceCached reports an expired entry as not cached")
+        void isPlaceCached_shouldRespectTtl() {
+            cache.getPlace(1);
+            assertTrue(cache.isPlaceCached(1));
+
+            clock.advance(TTL_MILLIS);
+            assertFalse(cache.isPlaceCached(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("invalidation")
+    class Invalidation {
+
+        @Test
+        @DisplayName("invalidating a place forces the next read back to the loader")
+        void invalidatePlace_shouldEvictTheEntry() {
+            cache.getPlace(1);
+            assertTrue(cache.invalidatePlace(1), "the entry was cached, so it should have been removed");
+
+            cache.getPlace(1);
+
+            assertEquals(2, placeLoader.callCount());
+            assertEquals(0, cache.getCacheStats().getHits());
+            assertEquals(1, cache.getCacheStats().getInvalidations());
+        }
+
+        @Test
+        @DisplayName("an update followed by invalidation is visible immediately, without waiting for the TTL")
+        void invalidateAfterUpdate_shouldServeFreshData() {
+            assertEquals("City Museum", cache.getPlace(1).getName());
+
+            // Simulates the admin flow: the row is updated, then its key is evicted.
+            placeLoader.store(place(1, "City Museum (east wing)"));
+            cache.invalidatePlace(1);
+
+            assertEquals("City Museum (east wing)", cache.getPlace(1).getName());
+        }
+
+        @Test
+        @DisplayName("a deleted place stops being served once its key is invalidated")
+        void invalidateAfterDelete_shouldStopServingTheRow() {
+            assertNotNull(cache.getPlace(1));
+
+            placeLoader.remove(1);
+            cache.invalidatePlace(1);
+
+            assertNull(cache.getPlace(1), "a deleted row must not survive in the cache");
+        }
+
+        @Test
+        @DisplayName("invalidating an uncached key changes nothing and is not counted")
+        void invalidateUncachedKey_shouldBeANoOp() {
+            assertFalse(cache.invalidatePlace(99));
+            assertFalse(cache.invalidateUser(99));
+
+            assertEquals(0, cache.getCacheStats().getInvalidations());
+        }
+
+        @Test
+        @DisplayName("invalidating one place leaves the others cached")
+        void invalidatePlace_shouldNotTouchOtherEntries() {
+            cache.getPlace(1);
+            cache.getPlace(2);
+
+            cache.invalidatePlace(1);
+
+            assertFalse(cache.isPlaceCached(1));
+            assertTrue(cache.isPlaceCached(2));
+        }
+
+        @Test
+        @DisplayName("invalidating a user forces the next read back to the loader")
+        void invalidateUser_shouldEvictTheEntry() {
+            cache.getUser(7);
+            assertTrue(cache.invalidateUser(7));
+
+            cache.getUser(7);
+
+            assertEquals(2, userLoader.callCount());
+            assertEquals(1, cache.getCacheStats().getInvalidations());
+        }
+    }
+
+    @Nested
+    @DisplayName("clearCache and resetStats")
+    class Clearing {
+
+        @Test
+        @DisplayName("clearCache empties both maps and counts every entry it dropped")
+        void clearCache_shouldEmptyBothMaps() {
+            cache.getPlace(1);
+            cache.getPlace(2);
+            cache.getUser(7);
+
+            cache.clearCache();
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getPlaceEntries());
+            assertEquals(0, stats.getUserEntries());
+            assertEquals(3, stats.getInvalidations());
+            assertFalse(cache.isPlaceCached(1));
+            assertFalse(cache.isUserCached(7));
+        }
+
+        @Test
+        @DisplayName("clearCache keeps the hit and miss history")
+        void clearCache_shouldPreserveCounters() {
+            cache.getPlace(1);
+            cache.getPlace(1);
+
+            cache.clearCache();
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(1, stats.getHits());
+            assertEquals(1, stats.getMisses());
+        }
+
+        @Test
+        @DisplayName("reads after a clear go back to the loader")
+        void clearCache_shouldForceReload() {
+            cache.getPlace(1);
+            cache.clearCache();
+            cache.getPlace(1);
+
+            assertEquals(2, placeLoader.callCount());
+        }
+
+        @Test
+        @DisplayName("clearing an empty cache counts nothing")
+        void clearEmptyCache_shouldCountNothing() {
+            cache.clearCache();
+
+            assertEquals(0, cache.getCacheStats().getInvalidations());
+        }
+
+        @Test
+        @DisplayName("resetStats zeroes the counters but keeps the cached entries")
+        void resetStats_shouldKeepEntries() {
+            cache.getPlace(1);
+            cache.getPlace(1);
+
+            cache.resetStats();
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getHits());
+            assertEquals(0, stats.getMisses());
+            assertEquals(1, stats.getPlaceEntries(), "the entry itself should survive a stats reset");
+
+            cache.getPlace(1);
+            assertEquals(1, cache.getCacheStats().getHits());
+            assertEquals(1, placeLoader.callCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("metrics reporting")
+    class Metrics {
+
+        @Test
+        @DisplayName("isPlaceCached and isUserCached do not count as lookups")
+        void cacheProbes_shouldNotRecordStats() {
+            cache.isPlaceCached(1);
+            cache.isUserCached(7);
+
+            CacheStats stats = cache.getCacheStats();
+            assertEquals(0, stats.getTotalLookups(), "probing must not distort the hit rate");
+        }
+
+        @Test
+        @DisplayName("a stats snapshot is frozen at the moment it was taken")
+        void statsSnapshot_shouldNotChangeAfterwards() {
+            cache.getPlace(1);
+            CacheStats snapshot = cache.getCacheStats();
+
+            cache.getPlace(1);
+            cache.getPlace(2);
+
+            assertEquals(0, snapshot.getHits(), "the older snapshot should not have moved");
+            assertEquals(1, snapshot.getMisses());
+            assertEquals(1, snapshot.getPlaceEntries());
+
+            assertEquals(1, cache.getCacheStats().getHits(), "the live cache should have moved on");
+        }
+
+        @Test
+        @DisplayName("the hit rate is zero before any lookup happens")
+        void hitRatio_shouldBeZeroWhenIdle() {
+            CacheStats stats = cache.getCacheStats();
+
+            assertEquals(0, stats.getTotalLookups());
+            assertEquals(0.0, stats.getHitRatio(), 1e-9);
+        }
+    }
+
+    @Nested
+    @DisplayName("construction")
+    class Construction {
+
+        @Test
+        @DisplayName("the default constructor uses a five-minute TTL")
+        void defaultConstructor_shouldUseDefaultTtl() {
+            assertEquals(CachedDBConnection.DEFAULT_TTL_MILLIS, new CachedDBConnection().getTtlMillis());
+        }
+
+        @Test
+        @DisplayName("a zero or negative TTL is rejected")
+        void nonPositiveTtl_shouldThrow() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new CachedDBConnection(0, placeLoader, userLoader));
+            assertThrows(IllegalArgumentException.class,
+                    () -> new CachedDBConnection(-1, placeLoader, userLoader));
+        }
+
+        @Test
+        @DisplayName("null loaders and a null clock are rejected")
+        void nullCollaborators_shouldThrow() {
+            assertThrows(NullPointerException.class,
+                    () -> new CachedDBConnection(TTL_MILLIS, null, userLoader));
+            assertThrows(NullPointerException.class,
+                    () -> new CachedDBConnection(TTL_MILLIS, placeLoader, null));
+            assertThrows(NullPointerException.class,
+                    () -> new CachedDBConnection(TTL_MILLIS, placeLoader, userLoader, null));
+        }
+    }
+
+    private static Place place(int id, String name) {
+        return new Place(id, name, "Museum", "Downtown", "A description.", 12.9, 77.6);
+    }
+
+    private static User user(String username) {
+        return new User(username, "hashed-password");
+    }
+
+    /**
+     * A clock the tests move by hand, so TTL expiry can be tested exactly and
+     * instantly instead of by sleeping.
+     */
+    private static final class MutableClock implements LongSupplier {
+        private long currentTimeMillis;
+
+        MutableClock(long startMillis) {
+            this.currentTimeMillis = startMillis;
+        }
+
+        void advance(long millis) {
+            currentTimeMillis += millis;
+        }
+
+        @Override
+        public long getAsLong() {
+            return currentTimeMillis;
+        }
+    }
+
+    /**
+     * A stand-in for the database that serves places from a map and counts how
+     * often it was asked — which is how the tests tell a hit from a miss.
+     */
+    private static final class CountingPlaceLoader implements CachedDBConnection.PlaceLoader {
+        private final Map<Integer, Place> rows = new HashMap<>();
+        private int calls;
+
+        void store(Place place) {
+            rows.put(place.getId(), place);
+        }
+
+        void remove(int placeId) {
+            rows.remove(placeId);
+        }
+
+        int callCount() {
+            return calls;
+        }
+
+        @Override
+        public Place load(int placeId) {
+            calls++;
+            return rows.get(placeId);
+        }
+    }
+
+    /**
+     * The user-side equivalent of {@link CountingPlaceLoader}.
+     */
+    private static final class CountingUserLoader implements CachedDBConnection.UserLoader {
+        private final Map<Integer, User> rows = new HashMap<>();
+        private int calls;
+
+        void store(int userId, User user) {
+            rows.put(userId, user);
+        }
+
+        int callCount() {
+            return calls;
+        }
+
+        @Override
+        public User load(int userId) {
+            calls++;
+            return rows.get(userId);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds soft deletion of user accounts. An administrator can deactivate a non-admin account, which leaves the row — and everything attached to it — in the database while refusing that account at login. Nothing is ever removed, so no history is lost.

**Schema**

- `db_setup.sql`: `ALTER TABLE users ADD COLUMN is_active BOOLEAN DEFAULT TRUE;`
- `migrations/V3__add_is_active_column.sql` (new): the same column for databases that already exist. `db_setup.sql` only creates tables `IF NOT EXISTS`, so without this migration anyone with an existing install hits `Unknown column 'is_active'` on their next login. It follows the repo's existing `V2__add_email_column.sql` pattern, and existing rows take the column default, so no current account is locked out by running it.

**Admin menu**

New entry **5. 🚫 Deactivate a user account**; Logout moves to 6.

**`deactivateUser()`**

Lists every active, non-admin account, prompts for a username, requires a typed `yes`, then runs:

```sql
UPDATE users SET is_active = FALSE WHERE username = ? AND role != 'ADMIN'
```

Three details worth a reviewer's attention:

1. The typed name is resolved against the listed accounts *before* the confirmation prompt, so "no active, non-admin account named 'x'" is reported directly instead of surfacing as a silent zero-row update after the admin has already confirmed. The `role != 'ADMIN'` guard stays in the UPDATE regardless — it is the real safety net, not the listing.
2. Matching is case-insensitive, so typing `John` finds the account stored as `john`, but the stored spelling is what gets updated and echoed back.
3. The outcome pauses on screen. The admin menu clears the terminal as soon as it is redrawn, so without a pause the result would flash past unread. The two lines that do this were extracted into `pauseUntilEnter()` and reused by the cache statistics screen, which had the same snippet.

**`login()`**

`LOGIN_QUERY` gains `AND is_active = TRUE`. That query alone cannot distinguish a deactivated account from a wrong password, so a *failed* login runs one follow-up check and prints:

> ❌ This account has been deactivated. Please contact an administrator.

only when the supplied credentials actually match a deactivated account. A wrong password still gets the generic "username or password incorrect" message, so this discloses nothing that a correct password would not already reveal.

**Deployment note:** existing databases must run `migrations/V3__add_is_active_column.sql` before this build is deployed. Fresh installs get the column from `db_setup.sql`.

Fixes #88

## Type of change

- [x] New feature (non-breaking change which adds functionality)

No existing API or behaviour breaks. The admin menu's keys shift (Logout 5 → 6) and the schema gains a column, which existing installs pick up through the migration above.

## How Has This Been Tested?

`mvn verify` — **100 tests pass, 0 Checkstyle violations**, jar builds.

No MySQL instance was available in this environment, so rather than stopping at "it compiles", the SQL was executed for real against in-memory **H2 in MySQL compatibility mode**. The harness pulls the application's actual query constants off `SmartCityApp` by reflection — the shipped strings, not retyped copies — and applies the real migration file to a `users` table built exactly as `db_setup.sql` builds it. All 12 checks pass:

- [x] Existing accounts stay active after the migration is applied
- [x] An active user can log in
- [x] Only active, non-admin accounts are offered for deactivation
- [x] Deactivating a normal user updates exactly one row
- [x] A deactivated user can no longer log in
- [x] A deactivated account is told apart from a wrong password
- [x] A wrong password is *not* misreported as a deactivation
- [x] An already-deactivated user drops off the list (no double deactivation)
- [x] An admin cannot be deactivated — the UPDATE matches zero rows
- [x] The admin can still log in afterwards
- [x] A newly registered user is active by default and can log in
- [x] Soft-deleted rows are still present in the table — nothing is destroyed

**To reproduce:**

```
mvn verify
```

**Not yet covered — worth a manual pass before merge:**

- H2 in MySQL mode is close to MySQL but not identical; the DDL and DML here are simple, but a run against a real MySQL instance would confirm it.
- The interactive flow itself — the account listing, the username prompt, and the yes/no confirmation — has not been driven end to end. Suggested manual script: log in as `admin` → option 5 → deactivate a test user → confirm the success message → log out → attempt to log in as that user and confirm the deactivation message → log back in as `admin` and confirm the user has dropped off the list.

⚠️ **Heads-up for reviewers:** `mvn test` currently fails on `main` for a reason unrelated to this PR. `src/test/java/com/smartcity/structures/RecentlyViewedManagerTest.java` sits under the main source root (`pom.xml` sets `sourceDirectory=src` and `testSourceDirectory=tests`), so it compiles as main code without JUnit on the classpath and the build stops there. This PR was verified with that one file moved aside temporarily; it is untouched in this diff. The fix is to move it into `tests/com/smartcity/structures/` — happy to open a separate PR for it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — the schema change is documented where it lives, in `db_setup.sql` and the new migration; no other document describes the users table.
- [x] My changes generate no new warnings (`mvn verify` reports 0 Checkstyle violations)
- [ ] I have added tests that prove my fix is effective or that my feature works — no JUnit tests were added. The logic lives in private static methods that open their own database connections, so testing it in the suite would mean refactoring the login and admin paths, which is beyond the scope of this issue. The behaviour was instead verified against a live H2 database as described above; happy to do the refactor in a follow-up if maintainers would like it covered.
- [x] New and existing unit tests pass locally with my changes (100 passing — see the caveat above about the pre-existing breakage on `main`)
- [ ] Any dependent changes have been merged and published in downstream modules — not applicable, no dependency changes.
