### PR TITLE
✨ Add: Search places by name in the Search Places menu

### DIFF
--- a/src/com/smartcity/main/SmartCityApp.java
+++ b/src/com/smartcity/main/SmartCityApp.java
@@ -38,6 +38,7 @@ public class SmartCityApp {
     private static final String CHECK_USERNAME_EXISTS_QUERY = "SELECT id FROM users WHERE username = ?";
     private static final String INSERT_USER_QUERY = "INSERT INTO users (username, password, email, role) VALUES (?, ?, ?, ?)";
     private static final String LOGIN_QUERY = "SELECT role FROM users WHERE username = ? AND password = ?";
+    private static final String SEARCH_BY_NAME_QUERY = "SELECT * FROM places WHERE LOWER(name) LIKE LOWER(?)";
     private static final String SEARCH_BY_CATEGORY_QUERY = "SELECT * FROM places WHERE LOWER(category) LIKE LOWER(?)";
     private static final String SEARCH_BY_LOCATION_QUERY = "SELECT * FROM places WHERE LOWER(location) LIKE LOWER(?)";
     private static final String INSERT_PLACE_QUERY = "INSERT INTO places (id, name, category, location, description, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?)";
@@ -963,7 +964,7 @@ public class SmartCityApp {
 
     /**
      * Displays the search submenu loop, allowing the user to search places
-     * by category, search by location, or go back to the previous menu.
+     * by category, by location, by name, or go back to the previous menu.
      */
     private static void searchPlacesMenu() {
         boolean inSearchMenu = true;
@@ -972,7 +973,8 @@ public class SmartCityApp {
             System.out.println("\n===== Search Places =====");
             System.out.println("1. 🏷️ Search by category");
             System.out.println("2. 📌 Search by location");
-            System.out.println("3. ⬅️ Back");
+            System.out.println("3. 🔤 Search by name");
+            System.out.println("4. ⬅️ Back");
             System.out.print("Enter your choice: ");
 
             int choice = scanner.nextInt();
@@ -988,11 +990,15 @@ public class SmartCityApp {
                     searchByLocation();
                     break;
                 case 3:
+                    // Search places by name
+                    searchByName();
+                    break;
+                case 4:
                     // Return to user menu
                     inSearchMenu = false;
                     break;
                 default:
-                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 3.");
+                    System.out.println("❌ Invalid choice '" + choice + "'. Please enter a number between 1 and 4.");
             }
         }
     }
@@ -1055,6 +1061,37 @@ public class SmartCityApp {
 
         } catch (SQLException e) {
             System.out.println("❌ Error: Failed to search places by location.");
+            System.out.println("   Error message: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Prompts the user for a name keyword and queries the database for
+     * all places whose name contains that keyword (case-insensitive),
+     * printing the matching results.
+     */
+    private static void searchByName() {
+        System.out.print("\nEnter place name to search: ");
+        String searchName = scanner.nextLine();
+
+        try (Connection connection = getConnectionOrPrintError()) {
+            if (connection == null) {
+                return;
+            }
+
+            try (PreparedStatement pstmt = connection.prepareStatement(SEARCH_BY_NAME_QUERY)) {
+                pstmt.setString(1, "%" + searchName + "%"); // Add wildcards for partial matching
+
+                try (ResultSet resultSet = pstmt.executeQuery()) {
+                    // Display search results
+                    System.out.println("\n🔍 Search Results for Name: " + searchName);
+                    System.out.println("-".repeat(50));
+                    placeResultPrintout(resultSet);
+                }
+            }
+
+        } catch (SQLException e) {
+            System.out.println("❌ Error: Failed to search places by name.");
             System.out.println("   Error message: " + e.getMessage());
         }
     }


### PR DESCRIPTION
Closes #19
Closes #37

## 📝 Description

The Search Places menu supported **category** and **location** but not **name**, so a user who remembered a place by name (e.g. "Central Museum") had no way to look it up directly. This adds that third option.

## 🛠️ Changes

- **`SEARCH_BY_NAME_QUERY`** constant — `SELECT * FROM places WHERE LOWER(name) LIKE LOWER(?)`, added alongside the existing search-query constants.
- **`searchByName()`** — mirrors `searchByCategory()` / `searchByLocation()` exactly: prompts for a keyword, wraps it in `%` wildcards for partial matching, and renders results through the shared `placeResultPrintout()`.
- **`searchPlacesMenu()`** — new option `3. 🔤 Search by name`; "Back" moves from `3` to `4`, and the invalid-choice message now reads *"between 1 and 4"*.

Display and Javadoc follow the surrounding style — no existing behaviour changed.

```
===== Search Places =====
1. 🏷️ Search by category
2. 📌 Search by location
3. 🔤 Search by name
4. ⬅️ Back
```

## ✅ Acceptance Criteria

- [x] "Search by name" option appears in the search submenu
- [x] Partial name matching works (`park` → `Central Riverside Park`)
- [x] Search is case-insensitive
- [x] "No results" message shown when nothing matches

## 🧪 How this was tested

Compiled with `javac` (JDK 21, MySQL connector on the classpath) and run against a real MySQL 8.4 database seeded with sample places:

| Input | Result |
|---|---|
| `park` | `Central Riverside Park`, `Westfield Retail Park` — partial match inside and at end of name |
| `riverside` | 5 matches across different categories |
| `CATHEDRAL` (uppercase) | matched `St Marys Cathedral` |
| `mUsEuM` (mixed case) | matched all 4 museums |
| `zzzznotreal` | no-results message shown, no crash |
| `9` (invalid menu choice) | `Invalid choice '9'. Please enter a number between 1 and 4.` |
| `4` (Back) | returns to the user menu, logout and exit still work |

## 📌 Note

The empty-result text comes from the shared `placeResultPrintout()` and currently reads *"No places available at the moment."* — a little off for a search. I deliberately left it alone because #34 covers standardising those messages across all search methods, and changing it here would collide with that work.